### PR TITLE
Moments: Change File Binary Type

### DIFF
--- a/examples/moments/backend/src/methods/create_moment.ts
+++ b/examples/moments/backend/src/methods/create_moment.ts
@@ -18,7 +18,7 @@ export const create_moment = async (client: MomentsClient): Promise<void> => {
      * The Token ID related to the moment (Optional)
      */
     tokenId: 6568008,
-    file: fileBuffer,
+    fileBinary: fileBuffer,
     author: '0x82AB2941Cf555CED5ad7Ed232a5B5f6083815FBC',
     fileType: mimeType,
   };

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "rollup": "^3.20.2"
   },
   "peerDependencies": {
-    "@poap-xyz/providers": "0.0.27",
-    "@poap-xyz/utils": "0.0.27"
+    "@poap-xyz/providers": "0.0.28",
+    "@poap-xyz/utils": "0.0.28"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,6 +29,6 @@
     "rollup": "^3.20.2"
   },
   "peerDependencies": {
-    "@poap-xyz/providers": "0.0.27"
+    "@poap-xyz/providers": "0.0.28"
   }
 }

--- a/packages/moments/src/client/MomentsClient.spec.ts
+++ b/packages/moments/src/client/MomentsClient.spec.ts
@@ -34,7 +34,7 @@ describe('MomentsClient', () => {
       const inputs: CreateMomentInput = {
         dropId: DROP_ID,
         tokenId: TOKEN_ID,
-        file: FILE,
+        fileBinary: FILE,
         fileType: FILE_TYPE,
         author: AUTHOR,
         onStepUpdate,

--- a/packages/moments/src/client/MomentsClient.ts
+++ b/packages/moments/src/client/MomentsClient.ts
@@ -32,7 +32,7 @@ export class MomentsClient {
     const { url, key } = await this.poapMomentsApi.getSignedUrl();
     void onStepUpdate(CreateSteps.UPLOADING_MEDIA);
     await this.poapMomentsApi.uploadFile(
-      input.file,
+      input.fileBinary,
       url,
       input.fileType,
       input.onFileUploadProgress,

--- a/packages/moments/src/client/dtos/create/CreateInput.ts
+++ b/packages/moments/src/client/dtos/create/CreateInput.ts
@@ -5,20 +5,20 @@ import { CreateSteps } from './CreateSteps';
  * @interface
  * @property {number} dropId - The ID of the drop related to the moment.
  * @property {number} [tokenId] - The ID of the token related to the moment (optional).
- * @property {Buffer} file - The buffer containing the file data.
- * @property {string} author - The author of the moment.
+ * @property {Uint8Array} fileBinary - The binary of the file to be uploaded.
+ * @property {string} author - The author of the moment. An Ethereum address.
  * @property {string} timeOut - The amount of time to wait until media is processed.
  * @property {string} fileType - The type of the file.
  * @property {(step: CreateSteps) => void | Promise<void>} [onStepUpdate] - Optional callback function to be called when the step changes.
  * @property {(progress: number) => void | Promise<void>} [onFileProgress] - Optional callback function to be called when the file upload progress change - progress is a number between 0 and 1.
  */
 export interface CreateMomentInput {
+  fileBinary: Uint8Array;
+  fileType: string;
+  author: string;
   dropId: number;
   tokenId?: number;
-  file: Buffer;
-  author: string;
   timeOut?: number;
-  fileType: string;
   onStepUpdate?: (step: CreateSteps) => void | Promise<void>;
   onFileUploadProgress?: (progress: number) => void | Promise<void>;
 }

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "rollup": "^3.20.2"
   },
   "peerDependencies": {
-    "@poap-xyz/providers": "0.0.27",
-    "@poap-xyz/utils": "0.0.27"
+    "@poap-xyz/providers": "0.0.28",
+    "@poap-xyz/utils": "0.0.28"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/providers/src/core/PoapMomentsApi/PoapMomentsApi.ts
+++ b/packages/providers/src/core/PoapMomentsApi/PoapMomentsApi.ts
@@ -50,19 +50,19 @@ export class PoapMomentsApi implements MomentsApiProvider {
 
   /**
    * Upload a file using the signed URL
-   * @param {Buffer} file - The file to be uploaded as a Buffer
+   * @param {Uint8Array} fileBinary - The file to be uploaded as a binary array
    * @param {string} fileType - The file type
    * @param {string} signedUrl - The signed URL for uploading the file
    * @param {(progress: number) => void} [onProgress] - Optional callback function to be called when the upload progress changes - progress is a number between 0 and 1
    * @returns {Promise<void>} - A Promise that resolves when the file has been uploaded
    */
   public async uploadFile(
-    file: Buffer,
+    fileBinary: Uint8Array,
     signedUrl: string,
     fileType: string,
     onProgress?: (progress: number) => void,
   ): Promise<void> {
-    await axios.put(signedUrl, file, {
+    await axios.put(signedUrl, fileBinary, {
       headers: {
         'Content-Type': fileType,
       },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Utils module for the poap.js library",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,8 +872,8 @@ __metadata:
   dependencies:
     rollup: ^3.20.2
   peerDependencies:
-    "@poap-xyz/providers": 0.0.27
-    "@poap-xyz/utils": 0.0.27
+    "@poap-xyz/providers": 0.0.28
+    "@poap-xyz/utils": 0.0.28
   languageName: unknown
   linkType: soft
 
@@ -883,7 +883,7 @@ __metadata:
   dependencies:
     rollup: ^3.20.2
   peerDependencies:
-    "@poap-xyz/providers": 0.0.27
+    "@poap-xyz/providers": 0.0.28
   languageName: unknown
   linkType: soft
 
@@ -893,8 +893,8 @@ __metadata:
   dependencies:
     rollup: ^3.20.2
   peerDependencies:
-    "@poap-xyz/providers": 0.0.27
-    "@poap-xyz/utils": 0.0.27
+    "@poap-xyz/providers": 0.0.28
+    "@poap-xyz/utils": 0.0.28
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

In Moments, change the file binary from `Buffer` to `UInt8Array`, so, now, it's compatible with both node and browsers.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the documentation accordingly.
