### PR TITLE
Fix typos

### DIFF
--- a/docs/pages/packages/moments.mdx
+++ b/docs/pages/packages/moments.mdx
@@ -6,7 +6,7 @@
 
 ## Features
 
-- Create a Moment attached to a Drop or an specific POAP
+- Create a Moment attached to a Drop or a specific POAP
 - Fetch multiple Moments
 - Fetch a single Moment
 

--- a/docs/pages/packages/providers.mdx
+++ b/docs/pages/packages/providers.mdx
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-@poap-xyz/providers is a package to use POAP providers that let you iteract with POAPs APIs. Also you can make your own provider by extending the interfaces.
+@poap-xyz/providers is a package to use POAP providers that let you interact with POAPs APIs. Also you can make your own provider by extending the interfaces.
 
 ## Features
 


### PR DESCRIPTION
 Fix typos
 
Also there is a typo in the description of the repo, "implemetation" instead of implementation