### PR TITLE
Fix typedoc targets

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -3,8 +3,9 @@
   "entryPoints": [
     "./packages/drops/src",
     "./packages/moments/src",
+    "./packages/poaps/src",
     "./packages/providers/src",
-    "./packages/types/src"
+    "./packages/utils/src"
   ],
   "exclude": ["**/node_modules/**", "**/*.spec.ts"],
   "out": "docs",


### PR DESCRIPTION
## Description

Was looking for a `types` package that doesn't exits, and `poaps` and `utils` was not included.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
