### PR TITLE
Improve Compass types and errors

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.1.0",
-    "@poap-xyz/utils": "0.1.0"
+    "@poap-xyz/providers": "0.1.6",
+    "@poap-xyz/utils": "0.1.6"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.1.2",
+  "version": "0.1.6",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.1.0",
-    "@poap-xyz/utils": "0.1.0",
+    "@poap-xyz/providers": "0.1.6",
+    "@poap-xyz/utils": "0.1.6",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.1.2",
+  "version": "0.1.6",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.1.0",
-    "@poap-xyz/utils": "0.1.0"
+    "@poap-xyz/providers": "0.1.6",
+    "@poap-xyz/utils": "0.1.6"
   },
   "engines": {
     "node": ">=18"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.1.2",
+  "version": "0.1.6",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -25,7 +25,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.1.0",
+    "@poap-xyz/utils": "0.1.6",
     "axios": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/providers/src/core/PoapCompass/PoapCompass.ts
+++ b/packages/providers/src/core/PoapCompass/PoapCompass.ts
@@ -111,7 +111,7 @@ export class PoapCompass implements CompassProvider {
    */
   async request<T>(
     query: string,
-    variables: Record<string, unknown>,
+    variables?: Record<string, unknown>,
   ): Promise<T> {
     return await this.fetchGraphQL<T>(query, variables ?? {});
   }

--- a/packages/providers/src/core/PoapCompass/PoapCompass.ts
+++ b/packages/providers/src/core/PoapCompass/PoapCompass.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { CompassProvider } from '../../ports/CompassProvider/CompassProvider';
 
 const DEFAULT_COMPASS_BASE_URL = 'https://public.compass.poap.tech/v1/graphql';
@@ -31,13 +29,13 @@ export class PoapCompass implements CompassProvider {
    * @function
    * @name PoapCompass#fetchGraphQL
    * @param {string} query - The GraphQL query to fetch.
-   * @param {Record<string, any>} variables - The variables to include with the query.
+   * @param {Record<string, unknown>} variables - The variables to include with the query.
    * @returns {Promise<R>} A Promise that resolves with the result of the query.
    * @template R - The type of the result.
    */
-  private async fetchGraphQL<R = any>(
+  private async fetchGraphQL<R>(
     query: string,
-    variables: Record<string, any>,
+    variables: Record<string, unknown>,
   ): Promise<R> {
     const endpoint = this.baseUrl;
 
@@ -75,17 +73,15 @@ export class PoapCompass implements CompassProvider {
    * @function
    * @name PoapCompass#request
    * @param {string} query - The GraphQL query to execute.
-   * @param {any} variables - The variables to include with the query.
+   * @param {Record<string, unknown>} [variables] - The variables to include with the query.
    * @returns {Promise<T>} A Promise that resolves with the result of the query.
    * @template T - The type of the result.
    */
-  async request<T>(query: string, variables: any): Promise<T> {
-    try {
-      const data = await this.fetchGraphQL<T>(query, variables);
-      return data;
-    } catch (error) {
-      throw error;
-    }
+  async request<T>(
+    query: string,
+    variables: Record<string, unknown>,
+  ): Promise<T> {
+    return await this.fetchGraphQL<T>(query, variables ?? {});
   }
 }
 

--- a/packages/providers/src/ports/CompassProvider/CompassProvider.ts
+++ b/packages/providers/src/ports/CompassProvider/CompassProvider.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-// TODO: Change variable type any to a more specific type
 /**
  * Provides a request method for executing GraphQL queries.
  *
@@ -12,9 +10,9 @@ export interface CompassProvider {
    * @function
    * @name CompassProvider#request
    * @param {string} query - The query string to execute.
-   * @param {Record<string, any>} variables - The variables to pass with the query.
+   * @param {Record<string, unknown>} [variables] - The variables to pass with the query.
    * @returns {Promise<T>} A Promise that resolves with the result of the query.
    * @template T - The type of the result.
    */
-  request<T>(query: string, variables: Record<string, any>): Promise<T>;
+  request<T>(query: string, variables?: Record<string, unknown>): Promise<T>;
 }

--- a/packages/providers/src/ports/CompassProvider/errors/CompassRequestError.ts
+++ b/packages/providers/src/ports/CompassProvider/errors/CompassRequestError.ts
@@ -1,0 +1,9 @@
+import { CompassErrors } from '../types/CompassErrors';
+
+export class CompassRequestError extends Error {
+  constructor(compassErrors: CompassErrors) {
+    super(
+      `Error fetching Compass data: ${compassErrors.errors.map((error) => error.message).join(', ')}`,
+    );
+  }
+}

--- a/packages/providers/src/ports/CompassProvider/errors/CompassRequestError.ts
+++ b/packages/providers/src/ports/CompassProvider/errors/CompassRequestError.ts
@@ -1,9 +1,13 @@
 import { CompassErrors } from '../types/CompassErrors';
+import { CompassError } from '../types/CompassError';
 
 export class CompassRequestError extends Error {
+  public errors: CompassError[];
+
   constructor(compassErrors: CompassErrors) {
     super(
       `Error fetching Compass data: ${compassErrors.errors.map((error) => error.message).join(', ')}`,
     );
+    this.errors = compassErrors.errors;
   }
 }

--- a/packages/providers/src/ports/CompassProvider/types/CompassError.ts
+++ b/packages/providers/src/ports/CompassProvider/types/CompassError.ts
@@ -1,0 +1,3 @@
+export interface CompassError {
+  message: string;
+}

--- a/packages/providers/src/ports/CompassProvider/types/CompassErrors.ts
+++ b/packages/providers/src/ports/CompassProvider/types/CompassErrors.ts
@@ -1,0 +1,5 @@
+import { CompassError } from './CompassError';
+
+export interface CompassErrors {
+  errors: CompassError[];
+}

--- a/packages/providers/test/PoapCompass.spec.ts
+++ b/packages/providers/test/PoapCompass.spec.ts
@@ -1,4 +1,5 @@
 import { PoapCompass } from '../src/core/PoapCompass/PoapCompass';
+import { CompassRequestError } from '../src/ports/CompassProvider/errors/CompassRequestError';
 import { mock } from 'node:test';
 
 describe('PoapCompass', () => {
@@ -40,9 +41,7 @@ describe('PoapCompass', () => {
 
     const poapCompass = new PoapCompass(apiKey);
 
-    await expect(poapCompass.request(query, variables)).rejects.toThrowError(
-      /Error fetching GraphQL data/,
-    );
+    await expect(poapCompass.request(query, variables)).rejects.toThrow(CompassRequestError);
   });
 
   it('should throw a network error when the request fails', async () => {

--- a/packages/providers/test/PoapCompass.spec.ts
+++ b/packages/providers/test/PoapCompass.spec.ts
@@ -17,6 +17,7 @@ describe('PoapCompass', () => {
     mock.method(global, 'fetch', () => {
       return Promise.resolve({
         ok: true,
+        status: 200,
         json: () => Promise.resolve(responseData),
       });
     });
@@ -35,6 +36,7 @@ describe('PoapCompass', () => {
     mock.method(global, 'fetch', () => {
       return Promise.resolve({
         ok: true,
+        status: 200,
         json: () => Promise.resolve(responseData),
       });
     });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.1.2",
+  "version": "0.1.6",
   "description": "Utils module for the poap.js library",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.1.0
-    "@poap-xyz/utils": 0.1.0
+    "@poap-xyz/providers": 0.1.6
+    "@poap-xyz/utils": 0.1.6
   languageName: unknown
   linkType: soft
 
@@ -893,8 +893,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.1.0
-    "@poap-xyz/utils": 0.1.0
+    "@poap-xyz/providers": 0.1.6
+    "@poap-xyz/utils": 0.1.6
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -904,43 +904,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.1.0
-    "@poap-xyz/utils": 0.1.0
+    "@poap-xyz/providers": 0.1.6
+    "@poap-xyz/utils": 0.1.6
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@*, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@*, @poap-xyz/providers@0.1.6, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.1.0
+    "@poap-xyz/utils": 0.1.6
     axios: ^1.3.5
     axios-mock-adapter: ^1.21.4
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@poap-xyz/providers@npm:0.1.0"
-  dependencies:
-    "@poap-xyz/utils": 0.1.0
-    axios: ^1.3.5
-  checksum: fe7f03cac15f160f0426d3084e020f2892f14439885ad8fd61dd96faec88dc45b02cedfdb861f742c8bc8f90ca4392facb11ac16ad73e6c2fa669592878071d3
-  languageName: node
-  linkType: hard
-
-"@poap-xyz/utils@*, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@*, @poap-xyz/utils@0.1.6, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown
   linkType: soft
-
-"@poap-xyz/utils@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@poap-xyz/utils@npm:0.1.0"
-  checksum: 3571311ad244f2a358e34752a2fc4d13f5ce2bb5b1facbd6824dbe6bd1b73e9cb94791989e8f22b89dee10877a3d5bca1ee093bbc0a3bb25b76bd5a5e966318a
-  languageName: node
-  linkType: hard
 
 "@rollup/plugin-commonjs@npm:^25.0.7":
   version: 25.0.7


### PR DESCRIPTION
## Description

The compass error management was not good to understand what was happening under. It had some problems like doing a `response.json` when the status code is not 200, double-throw without needed in request/fetchGraphQL and the catch was for everything instead of more fine-grained problems. Now there is a custom error that will return GraphQL errors. Also, changed the use of `any` for `unknown` and remove the `ts-ignore`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
