### PR TITLE
Allow compass requests to be aborted

### DIFF
--- a/packages/providers/src/core/PoapCompass/PoapCompass.ts
+++ b/packages/providers/src/core/PoapCompass/PoapCompass.ts
@@ -21,7 +21,7 @@ export class PoapCompass implements CompassProvider {
    */
   constructor(config: PoapCompassConfig) {
     this.apiKey = config.apiKey;
-    this.baseUrl = config.baseUrl || DEFAULT_COMPASS_BASE_URL;
+    this.baseUrl = config.baseUrl ?? DEFAULT_COMPASS_BASE_URL;
   }
 
   /**

--- a/packages/providers/src/core/PoapCompass/PoapCompass.ts
+++ b/packages/providers/src/core/PoapCompass/PoapCompass.ts
@@ -33,17 +33,20 @@ export class PoapCompass implements CompassProvider {
    * @name PoapCompass#fetchGraphQL
    * @param {string} query - The GraphQL query to fetch.
    * @param {Record<string, unknown>} variables - The variables to include with the query.
+   * @param {AbortSignal} signal - When given, the request can be aborted with its controller.
    * @returns {Promise<R>} A Promise that resolves with the result of the query.
    * @template R - The type of the result.
    */
   private async fetchGraphQL<R>(
     query: string,
     variables: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<R> {
     let response: Response;
 
     try {
       response = await fetch(this.baseUrl, {
+        signal,
         method: 'POST',
         body: JSON.stringify({
           query,
@@ -106,14 +109,16 @@ export class PoapCompass implements CompassProvider {
    * @name PoapCompass#request
    * @param {string} query - The GraphQL query to execute.
    * @param {Record<string, unknown>} [variables] - The variables to include with the query.
+   * @param {AbortSignal} signal - When given, the request can be aborted with its controller.
    * @returns {Promise<T>} A Promise that resolves with the result of the query.
    * @template T - The type of the result.
    */
   async request<T>(
     query: string,
     variables?: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<T> {
-    return await this.fetchGraphQL<T>(query, variables ?? {});
+    return await this.fetchGraphQL<T>(query, variables ?? {}, signal);
   }
 }
 

--- a/packages/providers/src/ports/CompassProvider/CompassProvider.ts
+++ b/packages/providers/src/ports/CompassProvider/CompassProvider.ts
@@ -11,8 +11,13 @@ export interface CompassProvider {
    * @name CompassProvider#request
    * @param {string} query - The query string to execute.
    * @param {Record<string, unknown>} [variables] - The variables to pass with the query.
+   * @param {AbortSignal} signal - When given, the request can be aborted with its controller.
    * @returns {Promise<T>} A Promise that resolves with the result of the query.
    * @template T - The type of the result.
    */
-  request<T>(query: string, variables?: Record<string, unknown>): Promise<T>;
+  request<T>(
+    query: string,
+    variables?: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T>;
 }


### PR DESCRIPTION
## Description

Add an `AbortSignal` to the compass provider request so it can be aborted.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
