### PR TITLE
Validate on compass that returns data

### DIFF
--- a/packages/providers/src/core/PoapCompass/PoapCompass.ts
+++ b/packages/providers/src/core/PoapCompass/PoapCompass.ts
@@ -2,6 +2,7 @@ import { CompassProvider } from '../../ports/CompassProvider/CompassProvider';
 import { CompassErrors } from '../../ports/CompassProvider/types/CompassErrors';
 import { CompassError } from '../../ports/CompassProvider/types/CompassError';
 import { CompassRequestError } from '../../ports/CompassProvider/errors/CompassRequestError';
+import { CompassMissingDataError } from '../../ports/CompassProvider/errors/CompassMissingDataError';
 
 const DEFAULT_COMPASS_BASE_URL = 'https://public.compass.poap.tech/v1/graphql';
 
@@ -66,11 +67,29 @@ export class PoapCompass implements CompassProvider {
 
     const body = await response.json();
 
-    if (this.isError(body)) {
-      throw new CompassRequestError(body);
-    }
+    this.handleResponseErrors(body);
 
     return body;
+  }
+
+  /**
+   * Throws error when the response contains error or does not contain any data.
+   *
+   * @private
+   * @function
+   * @name PoapCompass#handleResponseErrors
+   * @param {unknown} response - Some response from the GraphQL server.
+   * @throws {CompassRequestError} when the response contains errors.
+   * @throws {CompassMissingDataError} when the response doesn't contain any data.
+   */
+  private handleResponseErrors(response: unknown): void {
+    if (this.isError(response)) {
+      throw new CompassRequestError(response);
+    }
+
+    if (!this.hasData(response)) {
+      throw new CompassMissingDataError();
+    }
   }
 
   /**
@@ -95,6 +114,25 @@ export class PoapCompass implements CompassProvider {
           'message' in error &&
           typeof error.message === 'string',
       )
+    );
+  }
+
+  /**
+   * Returns true when the given response is a GraphQL data response.
+   *
+   * @private
+   * @function
+   * @name PoapCompass#hasData
+   * @param {unknown} response - Some response from the GraphQL server.
+   * @returns {boolean}
+   */
+  private hasData(response: unknown): response is { data: unknown } {
+    return (
+      response != null &&
+      typeof response === 'object' &&
+      'data' in response &&
+      response.data != null &&
+      typeof response.data === 'object'
     );
   }
 

--- a/packages/providers/src/ports/CompassProvider/errors/CompassMissingDataError.ts
+++ b/packages/providers/src/ports/CompassProvider/errors/CompassMissingDataError.ts
@@ -1,0 +1,5 @@
+export class CompassMissingDataError extends Error {
+  constructor() {
+    super('Compass response is missing data');
+  }
+}

--- a/packages/providers/src/ports/CompassProvider/errors/index.ts
+++ b/packages/providers/src/ports/CompassProvider/errors/index.ts
@@ -1,1 +1,2 @@
 export * from './CompassRequestError';
+export * from './CompassMissingDataError';

--- a/packages/providers/test/PoapCompass.spec.ts
+++ b/packages/providers/test/PoapCompass.spec.ts
@@ -1,9 +1,10 @@
+import { mock } from 'node:test';
 import { PoapCompass } from '../src/core/PoapCompass/PoapCompass';
 import { CompassRequestError } from '../src/ports/CompassProvider/errors/CompassRequestError';
-import { mock } from 'node:test';
+import { CompassMissingDataError } from '../src/ports/CompassProvider/errors/CompassMissingDataError';
 
 describe('PoapCompass', () => {
-  let apiKey;
+  let apiKey: string;
 
   beforeEach(() => {
     apiKey = 'test-api-key';
@@ -28,6 +29,26 @@ describe('PoapCompass', () => {
     expect(result).toEqual(responseData);
   });
 
+  it('should throw an error when the API returns no data', async () => {
+    const query = 'query { test }';
+    const variables = { key: 'value' };
+    const responseData = {};
+
+    mock.method(global, 'fetch', () => {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(responseData),
+      });
+    });
+
+    const poapCompass = new PoapCompass({ apiKey });
+
+    await expect(poapCompass.request(query, variables)).rejects.toThrow(
+      CompassMissingDataError,
+    );
+  });
+
   it('should throw an error when the API returns an error', async () => {
     const query = 'query { test }';
     const variables = { key: 'value' };
@@ -41,9 +62,11 @@ describe('PoapCompass', () => {
       });
     });
 
-    const poapCompass = new PoapCompass(apiKey);
+    const poapCompass = new PoapCompass({ apiKey });
 
-    await expect(poapCompass.request(query, variables)).rejects.toThrow(CompassRequestError);
+    await expect(poapCompass.request(query, variables)).rejects.toThrow(
+      CompassRequestError,
+    );
   });
 
   it('should throw a network error when the request fails', async () => {
@@ -54,9 +77,9 @@ describe('PoapCompass', () => {
       return Promise.reject(new Error('Network error'));
     });
 
-    const poapCompass = new PoapCompass(apiKey);
+    const poapCompass = new PoapCompass({ apiKey });
 
-    await expect(poapCompass.request(query, variables)).rejects.toThrowError(
+    await expect(poapCompass.request(query, variables)).rejects.toThrow(
       /Network error/,
     );
   });


### PR DESCRIPTION
## Description

This we need to consider if Compass will ever have a request that will not return any data --it has not been the case for the moment.

We can also move the validation to another method call `query` to be explicitly know that the request will return some data.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
