### PR TITLE
Use yarn in docs readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,13 +4,13 @@ This is a documentation website for POAP.js, a library for integrating with the 
 
 ## Getting Started
 
-To get started with this website, you'll need to install its dependencies and start the development server. You can do this using NPM:
+To get started with this website, you'll need to install its dependencies and start the development server. You can do this using yarn:
 
 ### NPM
 
 ```bash
-npm install
-npm run dev
+yarn install
+yarn dev
 ```
 
 Once the development server is running, you can view the website in your web browser by navigating to `http://localhost:3000`.


### PR DESCRIPTION
## Description

The docs readme was saying to use npm, but there is no `package-lock.json`, instead there is a `yarn.lock`, so yarn must be used instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
