### PR TITLE
Fix fetch POAPs with collector and without null address filter

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -20,7 +20,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Check package versions and publish
         run: yarn publish

--- a/.github/workflows/npm_publish_tag.yml
+++ b/.github/workflows/npm_publish_tag.yml
@@ -29,7 +29,7 @@ jobs:
           git config user.email "action@github.com"
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Check package versions and publish
         run: yarn publish-beta $GITHUB_REF_NAME

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Build packages
         run: yarn build

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.2.1",
-    "@poap-xyz/utils": "0.2.1"
+    "@poap-xyz/providers": "0.2.2",
+    "@poap-xyz/utils": "0.2.2"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.2.1",
-    "@poap-xyz/utils": "0.2.1",
+    "@poap-xyz/providers": "0.2.2",
+    "@poap-xyz/utils": "0.2.2",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.2.1",
-    "@poap-xyz/utils": "0.2.1"
+    "@poap-xyz/providers": "0.2.2",
+    "@poap-xyz/utils": "0.2.2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/poaps/src/PoapsClient.ts
+++ b/packages/poaps/src/PoapsClient.ts
@@ -75,11 +75,13 @@ export class PoapsClient {
       orderBy: createOrderBy<PoapsSortFields>(sortField, sortDir),
       where: {
         ...createAddressFilter('collector_address', collectorAddress),
-        ...createNotNullAddressFilter(
-          'collector_address',
-          filterZeroAddress,
-          filterDeadAddress,
-        ),
+        ...(collectorAddress == undefined
+          ? createNotNullAddressFilter(
+              'collector_address',
+              filterZeroAddress,
+              filterDeadAddress,
+            )
+          : {}),
         ...createEqFilter('chain', chain),
         ...createEqFilter('drop_id', dropId),
         ...createBetweenFilter('minted_on', mintedDateFrom, mintedDateTo),

--- a/packages/poaps/test/PoapsClient.spec.ts
+++ b/packages/poaps/test/PoapsClient.spec.ts
@@ -1,0 +1,188 @@
+import { MockProxy, anyString, mock } from 'jest-mock-extended';
+import { CompassProvider, TokensApiProvider } from '@poap-xyz/providers';
+import { PoapsClient } from '../src/PoapsClient';
+
+describe('PoapsClient', () => {
+  let compassProviderMock: MockProxy<CompassProvider>;
+  let tokensApiProviderMock: MockProxy<TokensApiProvider>;
+
+  let poapsClient: PoapsClient;
+
+  beforeEach(() => {
+    compassProviderMock = mock<CompassProvider>();
+    tokensApiProviderMock = mock<TokensApiProvider>();
+
+    poapsClient = new PoapsClient(compassProviderMock, tokensApiProviderMock);
+  });
+
+  describe('fetch', () => {
+    it('request all tokens except zero address and dead address when no filter is given', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {
+          collector_address: {
+            _nin: [
+              '0x0000000000000000000000000000000000000000',
+              '0x000000000000000000000000000000000000dead',
+            ],
+          },
+        },
+      });
+    });
+
+    it('request all tokens including zero address and dead address when those filters are given on false', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+        filterZeroAddress: false,
+        filterDeadAddress: false,
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {},
+      });
+    });
+
+    it('request all tokens except dead address but include zero address when filter is given on false', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+        filterZeroAddress: false,
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {
+          collector_address: {
+            _neq: '0x000000000000000000000000000000000000dead',
+          },
+        },
+      });
+    });
+
+    it('request all tokens except zero address but include dead address when filter is given on false', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+        filterDeadAddress: false,
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {
+          collector_address: {
+            _neq: '0x0000000000000000000000000000000000000000',
+          },
+        },
+      });
+    });
+
+    it('request tokens for collector when collectorAddress filter is given', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+        collectorAddress: '0xf6b6f07862a02c85628b3a9688beae07fea9c863',
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {
+          collector_address: {
+            _eq: '0xf6b6f07862a02c85628b3a9688beae07fea9c863',
+          },
+        },
+      });
+    });
+
+    it('request tokens for collector when collectorAddress filter is given without null address filter even when given', async () => {
+      // Given
+      compassProviderMock.request.mockResolvedValue({
+        data: {
+          poaps: [],
+        },
+      });
+
+      // When
+      await poapsClient.fetch({
+        limit: 1,
+        offset: 0,
+        collectorAddress: '0xf6b6f07862a02c85628b3a9688beae07fea9c863',
+        filterZeroAddress: true,
+        filterDeadAddress: true,
+      });
+
+      // Then
+      expect(compassProviderMock.request).toHaveBeenCalledWith(anyString(), {
+        limit: 1,
+        offset: 0,
+        orderBy: {},
+        where: {
+          collector_address: {
+            _eq: '0xf6b6f07862a02c85628b3a9688beae07fea9c863',
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/poaps/test/index.spec.ts
+++ b/packages/poaps/test/index.spec.ts
@@ -1,5 +1,0 @@
-describe('My Function', () => {
-  it('should return the correct result', () => {
-    // Define input and expected output
-  });
-});

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.2.1",
+    "@poap-xyz/utils": "0.2.2",
     "axios": "^1.3.5"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/utils/src/queries/filter.ts
+++ b/packages/utils/src/queries/filter.ts
@@ -57,8 +57,8 @@ export function createAddressFilter(
 
 export function createNotNullAddressFilter(
   key: string,
-  filterZeroAddress = true,
-  filterDeadAddress = true,
+  filterZeroAddress?: boolean,
+  filterDeadAddress?: boolean,
 ): FieldFilter<NeqFilter<string>> | FieldFilter<NinFilter<string>> {
   if (filterZeroAddress && filterDeadAddress) {
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.2.1
-    "@poap-xyz/utils": 0.2.1
+    "@poap-xyz/providers": 0.2.2
+    "@poap-xyz/utils": 0.2.2
   languageName: unknown
   linkType: soft
 
@@ -901,8 +901,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.2.1
-    "@poap-xyz/utils": 0.2.1
+    "@poap-xyz/providers": 0.2.2
+    "@poap-xyz/utils": 0.2.2
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -912,22 +912,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.2.1
-    "@poap-xyz/utils": 0.2.1
+    "@poap-xyz/providers": 0.2.2
+    "@poap-xyz/utils": 0.2.2
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@*, @poap-xyz/providers@0.2.1, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@*, @poap-xyz/providers@0.2.2, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.2.1
+    "@poap-xyz/utils": 0.2.2
     axios: ^1.3.5
     axios-mock-adapter: ^1.21.4
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@*, @poap-xyz/utils@0.2.1, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@*, @poap-xyz/utils@0.2.2, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

This fix that a fetch with `collectorAddress` and `filter*Address` returned incorrectly all except of the ones from the collector.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/documentation/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
