### PR TITLE
Drops created with Date

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.0",
-    "@poap-xyz/utils": "0.5.0"
+    "@poap-xyz/providers": "0.5.1",
+    "@poap-xyz/utils": "0.5.1"
   }
 }

--- a/packages/drops/src/DropsClient.ts
+++ b/packages/drops/src/DropsClient.ts
@@ -10,6 +10,7 @@ import {
   createOrderBy,
   createBoolFilter,
   createLikeFilter,
+  toPOAPDate,
 } from '@poap-xyz/utils';
 import { Drop } from './domain/Drop';
 import {
@@ -148,9 +149,18 @@ export class DropsClient {
       description: input.description,
       city: input.city,
       country: input.country,
-      start_date: input.startDate,
-      end_date: input.endDate,
-      expiry_date: input.expiryDate,
+      start_date:
+        input.startDate instanceof Date
+          ? toPOAPDate(input.startDate)
+          : input.startDate,
+      end_date:
+        input.endDate instanceof Date
+          ? toPOAPDate(input.endDate)
+          : input.endDate,
+      expiry_date:
+        input.expiryDate instanceof Date
+          ? toPOAPDate(input.expiryDate)
+          : input.expiryDate,
       event_url: input.eventUrl,
       virtual_event: input.virtualEvent,
       image: input.image,

--- a/packages/drops/src/types/CreateDropsInput.ts
+++ b/packages/drops/src/types/CreateDropsInput.ts
@@ -3,9 +3,9 @@ export interface CreateDropsInput {
   description: string;
   city: string;
   country: string;
-  startDate: string;
-  endDate: string;
-  expiryDate: string;
+  startDate: string | Date;
+  endDate: string | Date;
+  expiryDate: string | Date;
   eventUrl: string;
   virtualEvent: boolean;
   image: Blob;

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.0",
-    "@poap-xyz/utils": "0.5.0",
+    "@poap-xyz/providers": "0.5.1",
+    "@poap-xyz/utils": "0.5.1",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.0",
-    "@poap-xyz/utils": "0.5.0"
+    "@poap-xyz/providers": "0.5.1",
+    "@poap-xyz/utils": "0.5.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.5.0",
+    "@poap-xyz/utils": "0.5.1",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/utils/src/format/index.ts
+++ b/packages/utils/src/format/index.ts
@@ -1,1 +1,2 @@
 export * from './removeSpecialCharacters';
+export * from './toPOAPDate';

--- a/packages/utils/src/format/toPOAPDate.ts
+++ b/packages/utils/src/format/toPOAPDate.ts
@@ -1,0 +1,9 @@
+export function toPOAPDate(date: Date): string {
+  return date
+    .toLocaleDateString('en-US', {
+      month: '2-digit',
+      day: '2-digit',
+      year: 'numeric',
+    })
+    .replace(/\//g, '-');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.5.0
-    "@poap-xyz/utils": 0.5.0
+    "@poap-xyz/providers": 0.5.1
+    "@poap-xyz/utils": 0.5.1
   languageName: unknown
   linkType: soft
 
@@ -901,8 +901,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.5.0
-    "@poap-xyz/utils": 0.5.0
+    "@poap-xyz/providers": 0.5.1
+    "@poap-xyz/utils": 0.5.1
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -912,16 +912,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.5.0
-    "@poap-xyz/utils": 0.5.0
+    "@poap-xyz/providers": 0.5.1
+    "@poap-xyz/utils": 0.5.1
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@*, @poap-xyz/providers@0.5.0, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@*, @poap-xyz/providers@0.5.1, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.5.0
+    "@poap-xyz/utils": 0.5.1
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -929,7 +929,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@*, @poap-xyz/utils@0.5.0, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@*, @poap-xyz/utils@0.5.1, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

Allows drops to be created passing `Date` objects to `startDate`, `endDate` and `expiryDate` instead of formatted strings.

Fixes #65

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
