### PR TITLE
feat: Exclude minted drop email reservations in total count

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.3",
-    "@poap-xyz/utils": "0.5.3"
+    "@poap-xyz/providers": "0.5.4",
+    "@poap-xyz/utils": "0.5.4"
   }
 }

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -66,7 +66,7 @@ export class Drop {
       transferCount: Number(
         response.stats_by_chain_aggregate.aggregate.sum.transfer_count,
       ),
-      emailReservationCount: Number(response.email_claims_stats?.total) || 0,
+      emailReservationCount: Number(response.email_claims_stats?.reserved) || 0,
     });
   }
 

--- a/packages/drops/src/queries/PaginatedDrop.ts
+++ b/packages/drops/src/queries/PaginatedDrop.ts
@@ -41,7 +41,7 @@ export const PAGINATED_DROPS_QUERY = `
         }
       }
       email_claims_stats {
-        total
+        reserved
       }
       drop_image {
         gateways {

--- a/packages/drops/src/queries/SearchDrops.ts
+++ b/packages/drops/src/queries/SearchDrops.ts
@@ -42,7 +42,7 @@ export const SEARCH_DROPS_QUERY = `
         }
       }
       email_claims_stats {
-        total
+        reserved
       }
       drop_image {
         gateways {

--- a/packages/drops/src/types/DropResponse.ts
+++ b/packages/drops/src/types/DropResponse.ts
@@ -27,7 +27,7 @@ export interface DropResponse {
     };
   };
   email_claims_stats: {
-    total: number;
+    reserved: number;
   };
   drop_image: {
     gateways: Array<{

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.3",
-    "@poap-xyz/utils": "0.5.3",
+    "@poap-xyz/providers": "0.5.4",
+    "@poap-xyz/utils": "0.5.4",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.3",
-    "@poap-xyz/utils": "0.5.3"
+    "@poap-xyz/providers": "0.5.4",
+    "@poap-xyz/utils": "0.5.4"
   },
   "engines": {
     "node": ">=18"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.5.3",
+    "@poap-xyz/utils": "0.5.4",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.5.3
-    "@poap-xyz/utils": 0.5.3
+    "@poap-xyz/providers": 0.5.4
+    "@poap-xyz/utils": 0.5.4
   languageName: unknown
   linkType: soft
 
@@ -901,8 +901,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.5.3
-    "@poap-xyz/utils": 0.5.3
+    "@poap-xyz/providers": 0.5.4
+    "@poap-xyz/utils": 0.5.4
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -912,16 +912,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.5.3
-    "@poap-xyz/utils": 0.5.3
+    "@poap-xyz/providers": 0.5.4
+    "@poap-xyz/utils": 0.5.4
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.5.3, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.5.4, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.5.3
+    "@poap-xyz/utils": 0.5.4
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -929,7 +929,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.5.3, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.5.4, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
The email reservation count for a drop includes reservations that have been minted already, and therefore skews the total collectors count in place where you want to do: `mint count + reservation count = total collectors count`.

A possibility is to keep both counts (minted and reserved), and choose which is preferred on each client. Worth discussing if we think that's needed.