### PR TITLE
feat(Moments): Add function to create Moment without uploading media

### DIFF
--- a/docs/pages/packages/moments/UploadMoments.mdx
+++ b/docs/pages/packages/moments/UploadMoments.mdx
@@ -15,7 +15,7 @@ const fileBuffer = await fsPromises.readFile('path/to/poap-moment.png');
 const mimeType = mime.getType('path/to/poap-moment.png');
 
 // Upload it.
-const moment: Moment = await client.createMoment({
+const moment: Moment = await client.createMomentAndUploadMedia({
   /**
    * Moments are associated with a Drop.
    */

--- a/packages/moments/README.md
+++ b/packages/moments/README.md
@@ -61,7 +61,7 @@ const input: CreateMomentInput = {
     },
     timeOut: 5000, // Optional: Set a timeout for the media processing
 };
-const moment: Moment = await client.createMoment(input);
+const moment: Moment = await client.createMomentAndUploadMedia(input);
 ```
 
 Explanations for each step:

--- a/packages/moments/src/client/dtos/create/CreateAndUploadInput.ts
+++ b/packages/moments/src/client/dtos/create/CreateAndUploadInput.ts
@@ -1,7 +1,8 @@
 import { CreateSteps } from './CreateSteps';
+import { CreateMedia } from './CreateMedia';
 
 /**
- * Interface representing the input needed to create a moment.
+ * Interface representing the input needed to create a moment and upload media in one action.
  * @interface
  * @property {number} dropId - The ID of the drop related to the moment.
  * @property {number} [tokenId] - The ID of the token related to the moment (optional).
@@ -10,14 +11,15 @@ import { CreateSteps } from './CreateSteps';
  * @property {string} timeOut - The amount of time to wait until media is processed.
  * @property {(step: CreateSteps) => void | Promise<void>} [onStepUpdate] - Optional callback function to be called when the step changes.
  * @property {(progress: number) => void | Promise<void>} [onFileProgress] - Optional callback function to be called when the file upload progress change - progress is a number between 0 and 1.
- * @property {string[]} mediaKeys - The media keys previously uploaded to attach to the Moment.
+ * @property {CreateMedia[]} media - The media to be uploaded.
  */
-export interface CreateMomentInput {
+export interface CreateAndUploadMomentInput {
   author: string;
   description?: string;
   dropId: number;
   tokenId?: number;
   timeOut?: number;
   onStepUpdate?: (step: CreateSteps) => void | Promise<void>;
-  mediaKeys?: string[];
+  onFileUploadProgress?: (progress: number) => void | Promise<void>;
+  media?: CreateMedia[];
 }


### PR DESCRIPTION
## Description

* Rename `createMoment` to `createMomentAndUploadMedia`
* Create new `createMoment` function to create a Moment without uploading media.
* Change visibility to `public` for `uploadMedia` and `awaitForMediaProcessing`
  * Allows clients to upload media separately from Moments creation

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
