### PR TITLE
feat: Allow passing in fetch options to compass requests

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -15,3 +15,8 @@
 
 - Packages do not export input types anymore.
 - Drop properties are not exported anymore.
+
+## 0.6.0
+
+- `createMoment` does not upload media beforehand anymore. Use `createMomentAndUploadMedia` instead.
+- For compass requests, the fetch signal is not a parameter of the `PoapCompass.request` method anymore, it must be given through the new `options` parameter: `compass.request(url, { variables }, { signal })`.

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.5",
+    "@poap-xyz/providers": "0.5.6",
     "@poap-xyz/utils": "0.5.5"
   }
 }

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.6",
+    "@poap-xyz/providers": "0.6.0",
     "@poap-xyz/utils": "0.5.5"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/providers/src/ports/CompassProvider/CompassProvider.ts
+++ b/packages/providers/src/ports/CompassProvider/CompassProvider.ts
@@ -11,7 +11,7 @@ export interface CompassProvider {
    * @name CompassProvider#request
    * @param {string} query - The query string to execute.
    * @param {null | undefined | { readonly [variable: string]: unknown }} [variables] - The variables to pass with the query.
-   * @param {AbortSignal} signal - When given, the request can be aborted with its controller.
+   * @param {RequestInit} [options] - Options to pass to the fetch call.
    * @returns {Promise<{ data: D }>} A Promise that resolves with the result of the query.
    * @template D - The type of the result's data.
    * @template V - The type of the query's variables.
@@ -19,7 +19,7 @@ export interface CompassProvider {
   request<D, V = { readonly [variable: string]: unknown }>(
     query: string,
     variables?: null | undefined | V,
-    signal?: AbortSignal,
+    options?: RequestInit,
   ): Promise<{ data: D }>;
 
   /**
@@ -31,7 +31,7 @@ export interface CompassProvider {
    * @name CompassProvider#batch
    * @param {string} query - The query string to execute.
    * @param {{ readonly [variable: string]: unknown }[]} variables - The variables to pass with the each query.
-   * @param {AbortSignal} [signal] - When given, the requests can be aborted with its controller.
+   * @param {RequestInit} [options] - Options to pass to the fetch call.
    * @returns {Promise<{ data: D }[]>} A Promise that resolves with the results of the queries.
    * @template D - The type of the result's data.
    * @template V - The type of the query's variables.
@@ -39,6 +39,6 @@ export interface CompassProvider {
   batch<D, V = { readonly [variable: string]: unknown }>(
     query: string,
     variables: V[],
-    signal?: AbortSignal,
+    options?: RequestInit,
   ): Promise<{ data: D }[]>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,7 +884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.5.6
+    "@poap-xyz/providers": 0.6.0
     "@poap-xyz/utils": 0.5.5
   languageName: unknown
   linkType: soft
@@ -917,7 +917,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.5.6, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.6.0, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,7 +884,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.5.5
+    "@poap-xyz/providers": 0.5.6
     "@poap-xyz/utils": 0.5.5
   languageName: unknown
   linkType: soft
@@ -917,7 +917,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.5.5, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.5.6, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
@@ -928,6 +928,17 @@ __metadata:
     lodash.chunk: ^4.2.0
   languageName: unknown
   linkType: soft
+
+"@poap-xyz/providers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@poap-xyz/providers@npm:0.5.5"
+  dependencies:
+    "@poap-xyz/utils": 0.5.5
+    axios: ^1.6.8
+    lodash.chunk: ^4.2.0
+  checksum: 7648e7cbcd68610591a9a5a2123271a80791224ba9fb5d1c4fc86318514c863e9888450183cfc35aa2a45f6fc09a9f9e87299771f78fda807e9e0062a1bb4fd1
+  languageName: node
+  linkType: hard
 
 "@poap-xyz/utils@0.5.5, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Description

* Allows a client to disable cache in next.js requests for example
* Signal can still be given through these options

Feedback welcome.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
