### PR TITLE
feat: Add method to transform a Serializable Drop into a Drop

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -108,6 +108,36 @@ export class Drop {
     });
   }
 
+  public static fromSerializableObject(
+    serializableDrop: SerializableDrop,
+  ): Drop {
+    return new Drop({
+      id: serializableDrop.id,
+      fancyId: serializableDrop.fancyId,
+      name: serializableDrop.name,
+      description: serializableDrop.description,
+      city: serializableDrop.city,
+      country: serializableDrop.country,
+      channel: serializableDrop.channel,
+      platform: serializableDrop.platform,
+      locationType: serializableDrop.locationType,
+      dropUrl: serializableDrop.dropUrl,
+      imageUrl: serializableDrop.imageUrl,
+      originalImageUrl: serializableDrop.originalImageUrl,
+      animationUrl: serializableDrop.animationUrl,
+      year: serializableDrop.year,
+      timezone: serializableDrop.timezone,
+      private: serializableDrop.private,
+      startDate: new Date(serializableDrop.startDate),
+      createdDate: new Date(serializableDrop.createdDate),
+      expiryDate: new Date(serializableDrop.expiryDate),
+      endDate: new Date(serializableDrop.endDate),
+      poapCount: serializableDrop.poapCount,
+      transferCount: serializableDrop.transferCount,
+      emailReservationCount: serializableDrop.emailReservationCount,
+    });
+  }
+
   // eslint-disable-next-line max-statements
   constructor(properties: DropProperties) {
     this.id = properties.id;
@@ -168,7 +198,7 @@ export class Drop {
   }
 }
 
-interface SerializableDrop {
+export interface SerializableDrop {
   id: number;
   fancyId: string;
   name: string;

--- a/packages/drops/src/index.ts
+++ b/packages/drops/src/index.ts
@@ -1,3 +1,3 @@
 export { DropsClient } from './DropsClient';
-export { Drop } from './domain/Drop';
+export { Drop, SerializableDrop } from './domain/Drop';
 export { DropsSortFields } from './types/DropsSortFields';


### PR DESCRIPTION
## Description

* Adds a deserialization method to the `Drop` class.
* Also export the `SerializableDrop` interface for strict typescript check purpose in clients.

Closes #74 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
