### PR TITLE
build: Upgrade providers package version on poaps package

### DIFF
--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.5.5",
+    "@poap-xyz/providers": "0.7.0",
     "@poap-xyz/utils": "0.5.5"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,7 +912,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.5.5
+    "@poap-xyz/providers": 0.7.0
     "@poap-xyz/utils": 0.5.5
   languageName: unknown
   linkType: soft
@@ -928,17 +928,6 @@ __metadata:
     lodash.chunk: ^4.2.0
   languageName: unknown
   linkType: soft
-
-"@poap-xyz/providers@npm:0.5.5":
-  version: 0.5.5
-  resolution: "@poap-xyz/providers@npm:0.5.5"
-  dependencies:
-    "@poap-xyz/utils": 0.5.5
-    axios: ^1.6.8
-    lodash.chunk: ^4.2.0
-  checksum: 7648e7cbcd68610591a9a5a2123271a80791224ba9fb5d1c4fc86318514c863e9888450183cfc35aa2a45f6fc09a9f9e87299771f78fda807e9e0062a1bb4fd1
-  languageName: node
-  linkType: hard
 
 "@poap-xyz/utils@0.5.5, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Description

The poap package was still on a previous version, making the Compass Provider incompatible with version 0.7.0 of `@poap-xyz/providers`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
