### PR TITLE
refactor: Make the drop IDs property optional when creating a Moment

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.1",
-    "@poap-xyz/utils": "0.7.1"
+    "@poap-xyz/providers": "0.7.2",
+    "@poap-xyz/utils": "0.7.2"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.1",
-    "@poap-xyz/utils": "0.7.1",
+    "@poap-xyz/providers": "0.7.2",
+    "@poap-xyz/utils": "0.7.2",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/moments/src/client/MomentsClient.spec.ts
+++ b/packages/moments/src/client/MomentsClient.spec.ts
@@ -152,5 +152,41 @@ describe('MomentsClient', () => {
       expect(onStepUpdate).toHaveBeenCalledWith(CreateSteps.FINISHED);
       expect(onStepUpdate).toHaveBeenCalledTimes(2);
     });
+
+    it('should allow creation of a moment without any drops', async () => {
+      // GIVEN
+      const client = new MomentsClient(
+        poapMomentsAPIMocked,
+        compassProviderMocked,
+      );
+      const inputs: CreateMomentInput = {
+        mediaKeys: MEDIA_KEYS,
+        author: AUTHOR,
+        description: DESCRIPTION,
+      };
+      poapMomentsAPIMocked.createMoment.mockResolvedValue({
+        id: MOMENT_ID,
+        author: AUTHOR,
+        createdOn: new Date().toISOString(),
+        dropIds: [],
+      });
+
+      const EXPECTED_MOMENT_CREATE_INPUT = {
+        author: AUTHOR,
+        description: DESCRIPTION,
+        mediaKeys: MEDIA_KEYS,
+      };
+
+      // WHEN
+      const moment = await client.createMoment(inputs);
+
+      // THEN
+      expect(moment.id).toBe(MOMENT_ID);
+      expect(moment.author).toBe(AUTHOR);
+      expect(moment.dropIds).toEqual([]);
+      expect(poapMomentsAPIMocked.createMoment).toHaveBeenCalledWith(
+        EXPECTED_MOMENT_CREATE_INPUT,
+      );
+    });
   });
 });

--- a/packages/moments/src/client/dtos/create/CreateAndUploadInput.ts
+++ b/packages/moments/src/client/dtos/create/CreateAndUploadInput.ts
@@ -8,7 +8,7 @@ export interface CreateAndUploadMomentInput {
   /** The description of the moment. */
   description?: string;
   /** The IDs of the drops to associate to the moment. */
-  dropIds: number[];
+  dropIds?: number[];
   /** The amount of time to wait until media is processed. */
   timeOut?: number;
   /** Callback function to be called when the progress step changes. */

--- a/packages/moments/src/client/dtos/create/CreateInput.ts
+++ b/packages/moments/src/client/dtos/create/CreateInput.ts
@@ -7,7 +7,7 @@ export interface CreateMomentInput {
   /** The description of the moment. */
   description?: string;
   /** The IDs of the drops to associate to the moment. */
-  dropIds: number[];
+  dropIds?: number[];
   /** The amount of time to wait until media is processed. */
   timeOut?: number;
   /** Callback function to be called when the step changes. */

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.1",
-    "@poap-xyz/utils": "0.7.1"
+    "@poap-xyz/providers": "0.7.2",
+    "@poap-xyz/utils": "0.7.2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.7.1",
+    "@poap-xyz/utils": "0.7.2",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/providers/src/ports/MomentsApiProvider/types/CreateMomentInput.ts
+++ b/packages/providers/src/ports/MomentsApiProvider/types/CreateMomentInput.ts
@@ -1,7 +1,7 @@
 /** Object describing the input required to create a Moment */
 export interface CreateMomentInput {
   /** The IDs of the Drops to associate with the Moment */
-  dropIds: number[];
+  dropIds?: number[];
   /** The author of the Moment. An Ethereum address. */
   author: string;
   /** The media keys associated with the Moment */

--- a/packages/providers/test/PoapMomentsApi.spec.ts
+++ b/packages/providers/test/PoapMomentsApi.spec.ts
@@ -132,5 +132,23 @@ describe('PoapMomentsApi', () => {
       api = new PoapMomentsApi({});
       await expect(api.createMoment(createMomentInput)).rejects.toThrow();
     });
+
+    it('should allow Moment creation without any drop', async () => {
+      const mockResponse: CreateMomentResponse = {
+        id: '1',
+        author: '0x1234',
+        createdOn: '2023-01-01T00:00:00.000Z',
+        dropIds: [],
+        description: 'This is a test description',
+      };
+
+      axiosMocked.onPost(`${BASE_URL}/moments`).reply(200, mockResponse);
+
+      const input = { ...createMomentInput };
+      delete input.dropIds;
+
+      const result = await api.createMoment(input);
+      expect(result).toEqual(mockResponse);
+    });
   });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.7.1
-    "@poap-xyz/utils": 0.7.1
+    "@poap-xyz/providers": 0.7.2
+    "@poap-xyz/utils": 0.7.2
   languageName: unknown
   linkType: soft
 
@@ -901,8 +901,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.7.1
-    "@poap-xyz/utils": 0.7.1
+    "@poap-xyz/providers": 0.7.2
+    "@poap-xyz/utils": 0.7.2
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -912,16 +912,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.7.1
-    "@poap-xyz/utils": 0.7.1
+    "@poap-xyz/providers": 0.7.2
+    "@poap-xyz/utils": 0.7.2
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.7.1, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.7.2, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.7.1
+    "@poap-xyz/utils": 0.7.2
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -929,7 +929,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.7.1, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.7.2, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

To create a Moment without any drop links, it was mandatory to pass in an empty array. This is not a requirement in the API, so this PR removes the requirement from the SDK as well.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
