### PR TITLE
Fix Drop from Compass without Image

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.5.6",
+  "version": "0.7.3",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -29,7 +29,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.2",
-    "@poap-xyz/utils": "0.7.2"
+    "@poap-xyz/providers": "0.7.3",
+    "@poap-xyz/utils": "0.7.3"
   }
 }

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -78,7 +78,7 @@ export class Drop {
           [gateway.type.toLowerCase()]: gateway.url,
         }),
         defaultImage,
-      ) ?? defaultImage
+      )
     );
   }
 

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -71,14 +71,12 @@ export class Drop {
       return defaultImage;
     }
 
-    return (
-      response.drop_image.gateways.reduce(
-        (images, gateway) => ({
-          ...images,
-          [gateway.type.toLowerCase()]: gateway.url,
-        }),
-        defaultImage,
-      )
+    return response.drop_image.gateways.reduce(
+      (images, gateway) => ({
+        ...images,
+        [gateway.type.toLowerCase()]: gateway.url,
+      }),
+      defaultImage,
     );
   }
 

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -72,7 +72,7 @@ export class Drop {
     }
 
     return (
-      response.drop_image?.gateways.reduce(
+      response.drop_image.gateways.reduce(
         (images, gateway) => ({
           ...images,
           [gateway.type.toLowerCase()]: gateway.url,

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -72,13 +72,13 @@ export class Drop {
     }
 
     return (
-      response.drop_image?.gateways?.reduce(
+      response.drop_image?.gateways.reduce(
         (images, gateway) => ({
           ...images,
           [gateway.type.toLowerCase()]: gateway.url,
         }),
         defaultImage,
-      ) || defaultImage
+      ) ?? defaultImage
     );
   }
 

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -69,8 +69,12 @@ export class Drop {
       original: response.image_url,
     };
 
+    if (!response.drop_image) {
+      return defaultImage;
+    }
+
     return (
-      response.drop_image?.gateways.reduce(
+      response.drop_image?.gateways?.reduce(
         (images, gateway) => ({
           ...images,
           [gateway.type.toLowerCase()]: gateway.url,

--- a/packages/drops/src/domain/Drop.ts
+++ b/packages/drops/src/domain/Drop.ts
@@ -1,5 +1,6 @@
 import { DropResponse as ProviderDropResponse } from '@poap-xyz/providers';
 import { DropResponse } from '../types/DropResponse';
+import { DropImage } from './DropImage';
 
 export class Drop {
   id: number;
@@ -60,11 +61,8 @@ export class Drop {
     });
   }
 
-  private static getDropImageFromCompass(response: DropResponse): {
-    crop: string;
-    original: string;
-  } {
-    const defaultImage = {
+  private static getDropImageFromCompass(response: DropResponse): DropImage {
+    const defaultImage: DropImage = {
       crop: response.image_url,
       original: response.image_url,
     };

--- a/packages/drops/src/domain/DropImage.ts
+++ b/packages/drops/src/domain/DropImage.ts
@@ -1,0 +1,4 @@
+export interface DropImage {
+  crop: string;
+  original: string;
+}

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.2",
-    "@poap-xyz/utils": "0.7.2",
+    "@poap-xyz/providers": "0.7.3",
+    "@poap-xyz/utils": "0.7.3",
     "uuid": "^9.0.0"
   },
   "engines": {

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.7.0",
+  "version": "0.7.3",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.5.5",
+  "version": "0.7.3",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -26,8 +26,8 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/providers": "0.7.2",
-    "@poap-xyz/utils": "0.7.2"
+    "@poap-xyz/providers": "0.7.3",
+    "@poap-xyz/utils": "0.7.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.7.0",
+  "version": "0.7.3",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -26,7 +26,7 @@
     "build": "rollup -c --bundleConfigAsCjs"
   },
   "dependencies": {
-    "@poap-xyz/utils": "0.7.2",
+    "@poap-xyz/utils": "0.7.3",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.5.5",
+  "version": "0.7.3",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,8 +884,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.7.2
-    "@poap-xyz/utils": 0.7.2
+    "@poap-xyz/providers": 0.7.3
+    "@poap-xyz/utils": 0.7.3
   languageName: unknown
   linkType: soft
 
@@ -901,8 +901,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.7.2
-    "@poap-xyz/utils": 0.7.2
+    "@poap-xyz/providers": 0.7.3
+    "@poap-xyz/utils": 0.7.3
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -912,16 +912,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.7.2
-    "@poap-xyz/utils": 0.7.2
+    "@poap-xyz/providers": 0.7.3
+    "@poap-xyz/utils": 0.7.3
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.7.2, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.7.3, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.7.2
+    "@poap-xyz/utils": 0.7.3
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -929,7 +929,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.7.2, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.7.3, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

This fixes when a Drop has no `drop_image` returned.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
