### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/pages/packages/poaps/Mint.mdx
+++ b/docs/pages/packages/poaps/Mint.mdx
@@ -1,6 +1,6 @@
 # Mint POAP
 
-Minting a POAP is an asynchronous process, but with `PoapsClient` it can simplified
+Minting a POAP is an asynchronous process, but with `PoapsClient` it can be simplified
 to only one method call.
 
 ## Async
@@ -35,7 +35,7 @@ const poap: POAP = (
 
 ## Sync
 
-All the minting processes can done automatically by `PoapsClient`.
+All the minting processes can be done automatically by `PoapsClient`.
 
 ```typescript
 import { POAP } from '@poap-xyz/poaps';

--- a/docs/pages/packages/utils.mdx
+++ b/docs/pages/packages/utils.mdx
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/utils` is a package that contains auxiliar functions.
+`@poap-xyz/utils` is a package that contains auxiliary functions.
 
 ## Features
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "can simplified" to "can be simplified".
Corrected "can done" to "can be done".
Corrected "auxiliar functions" to "auxiliary functions".

Please review the changes and let me know if any additional changes are needed.