### PR TITLE
 Fix typos in documentation files

### DIFF
--- a/packages/moments/README.md
+++ b/packages/moments/README.md
@@ -21,7 +21,7 @@ npm install @poap-xyz/moments @poap-xyz/utils @poap-xyz/providers axios
 ### Yarn
 
 ```bash
-yarn add @poap-xyz/moments @poap-xyz/utils @poap-xyz/providers axio
+yarn add @poap-xyz/moments @poap-xyz/utils @poap-xyz/providers axios
 ```
 
 ## Usage

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/providers` is a package to use POAP providers that let you iteract with POAPs APIs. Also
+`@poap-xyz/providers` is a package to use POAP providers that let you interact with POAPs APIs. Also
 you can make your own provider by extending the interfaces.
 
 ## Features

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/utils` is a package that contains auxiliar functions and common types.
+`@poap-xyz/utils` is a package that contains auxiliary functions and common types.
 
 ## Features
 


### PR DESCRIPTION


## Changes Made

### 1. packages/moments/README.md
- Fixed: `axio` → `axios`
- Reason: Corrected the package name for the Axios HTTP client library

### 2. packages/providers/README.md
- Fixed: `iteract` → `interact`
- Reason: Corrected spelling of the word "interact"

### 3. packages/utils/README.md
- Fixed: `auxiliar` → `auxiliary`
- Reason: Corrected spelling of the word "auxiliary"

## Description

This PR fixes several typos in the documentation files:
1. Corrects the Axios package name in the installation command
2. Fixes the spelling of "interact" in the providers package description
3. Corrects the spelling of "auxiliary" in the utils package description

These changes improve the documentation accuracy and readability for users of the POAP packages.

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] Documentation has been updated
- [x] Spelling and grammar have been checked
- [x] Changes are consistent across all documentation files
