### PR TITLE
feat: Add `_is_null` filter in query helpers

### DIFF
--- a/docs/pages/packages/utils/Queries.mdx
+++ b/docs/pages/packages/utils/Queries.mdx
@@ -79,6 +79,7 @@ The possible filters to create are:
 - `createInFilter`: if the field is contained in any of the given values.
 - `createNinFilter`: not contained in the given values.
 - `createBetweenFilter`: from and to values, mostly used for dates.
+- `createIsNullFilter`: to check if the field is null.
 
 ### Use of DOT notation
 

--- a/packages/utils/src/queries/filter.ts
+++ b/packages/utils/src/queries/filter.ts
@@ -10,6 +10,7 @@ import {
   LteFilter,
   NeqFilter,
   NinFilter,
+  IsNullFilter,
   Value,
 } from '../types/filter';
 import { ZERO_ADDRESS, DEAD_ADDRESS } from '../constants';
@@ -145,4 +146,11 @@ export function createBetweenFilter<V = Value>(
         betweenFilter,
       )
     : {};
+}
+
+export function createIsNullFilter(
+  key: string,
+  value: boolean,
+): FieldFilter<IsNullFilter> {
+  return createField<IsNullFilter>(key, { _is_null: value });
 }

--- a/packages/utils/src/types/filter.ts
+++ b/packages/utils/src/types/filter.ts
@@ -36,6 +36,10 @@ export interface LteFilter<V = Value> {
   _lte: V;
 }
 
+export interface IsNullFilter {
+  _is_null: boolean;
+}
+
 export type AnyFilter = Partial<EqFilter> &
   Partial<NeqFilter> &
   Partial<LikeFilter> &
@@ -44,7 +48,8 @@ export type AnyFilter = Partial<EqFilter> &
   Partial<GtFilter> &
   Partial<GteFilter> &
   Partial<LtFilter> &
-  Partial<LteFilter>;
+  Partial<LteFilter> &
+  Partial<IsNullFilter>;
 
 export type FieldFilter<F = AnyFilter> = {
   [key: string]: FieldFilter<F> | F;


### PR DESCRIPTION
## Description

Add `_is_null` query helper.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
