### PR TITLE
build: Specify type declaration file in exports

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {
@@ -30,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.4",
-    "@poap-xyz/utils": "0.7.4"
+    "@poap-xyz/providers": "0.7.5",
+    "@poap-xyz/utils": "0.7.5"
   }
 }

--- a/packages/frames/package.json
+++ b/packages/frames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/frames",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Frames module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {
@@ -30,8 +31,8 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.4",
-    "@poap-xyz/utils": "0.7.4",
+    "@poap-xyz/providers": "0.7.5",
+    "@poap-xyz/utils": "0.7.5",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {
@@ -30,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.4",
-    "@poap-xyz/utils": "0.7.4"
+    "@poap-xyz/providers": "0.7.5",
+    "@poap-xyz/utils": "0.7.5"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {
@@ -30,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/utils": "0.7.4",
+    "@poap-xyz/utils": "0.7.5",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -9,7 +9,8 @@
   "exports": {
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs",
-    "browser": "./dist/umd/index.js"
+    "browser": "./dist/umd/index.js",
+    "types": "./dist/cjs/index.d.ts"
   },
   "type": "module",
   "repository": {

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -7,12 +7,6 @@ import nodePolyfills from 'rollup-plugin-node-polyfills';
 
 const pkg = require(path.resolve(process.cwd(), 'package.json'));
 
-const replaceExtension = (filePath, newExtension) => {
-  const currentExtension = path.extname(filePath);
-  const fileNameWithoutExtension = filePath.slice(0, -currentExtension.length);
-  return `${fileNameWithoutExtension}.${newExtension}`;
-};
-
 const configs = [
   {
     context: 'window',
@@ -26,9 +20,7 @@ const configs = [
     },
     cache: false,
     plugins: [
-      typescript({
-        tsconfig: `./tsconfig.json`,
-      }),
+      typescript({ tsconfig: './tsconfig.json' }),
       nodeResolve({
         browser: true,
       }),
@@ -37,7 +29,7 @@ const configs = [
     ],
   },
   {
-    input: `./src/index.ts`,
+    input: './src/index.ts',
     output: [
       {
         file: pkg.main,
@@ -51,24 +43,10 @@ const configs = [
         sourcemap: true,
         exports: 'named',
       },
-      {
-        file: replaceExtension(pkg.typings, 'cts'),
-        format: 'cjs',
-        sourcemap: false,
-        exports: 'named',
-      },
-      {
-        file: replaceExtension(pkg.module, 'd.mts'),
-        format: 'esm',
-        sourcemap: false,
-        exports: 'named',
-      },
     ],
     external: ['axios'],
     plugins: [
-      typescript({
-        tsconfig: `./tsconfig.json`,
-      }),
+      typescript({ tsconfig: './tsconfig.json' }),
       nodeResolve({
         preferBuiltins: true,
         browser: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,8 +931,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.7.4
-    "@poap-xyz/utils": 0.7.4
+    "@poap-xyz/providers": 0.7.5
+    "@poap-xyz/utils": 0.7.5
   languageName: unknown
   linkType: soft
 
@@ -948,8 +948,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.7.4
-    "@poap-xyz/utils": 0.7.4
+    "@poap-xyz/providers": 0.7.5
+    "@poap-xyz/utils": 0.7.5
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -959,16 +959,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.7.4
-    "@poap-xyz/utils": 0.7.4
+    "@poap-xyz/providers": 0.7.5
+    "@poap-xyz/utils": 0.7.5
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.7.4, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.7.5, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.7.4
+    "@poap-xyz/utils": 0.7.5
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -976,7 +976,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.7.4, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.7.5, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

It's currently not possible to use interfaces and types in consuming projects with `moduleResolution: bundler` configured, because the `.d.mts` file contains bundled js code instead of the type declarations.

The issue comes from [this commit](https://github.com/poap-xyz/poap.js/commit/b13d10f8f0ba55247abbeb690e127f66aa6e1979). The original intention was to rename `.d.ts` into `.d.mts` and `.d.cts`. However, the result was that `.cjs` and `.mts` files were mistakenly renamed to `.d.cts` and `.d.mts`, respectively.

It had good intentions, because it's true that typescript will prioritize reading a `.mts` file over a `.d.ts` file when using `esm`.

To fix this, this PR removes this step in the build process, and explicitly defines the path for type declarations in the package exports instead, making any problematic renaming unnecessary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
