### PR TITLE
feat: Improve how values are validated in filter utils

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,8 @@ for dir in "${DIRS[@]}"; do
     exit 1
   fi
 
+  printf "\nBuilding package: $dir\n"
+
   # Run the build command
   if ! yarn build; then
     echo "Error: Failed to run 'yarn build' in directory: packages/$dir"

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -29,3 +29,7 @@
 - The token ID is no longer a property of the Moment type.
 - `patchMoment` is no longer a method of the Moments client.
 - It is no longer possible to order fetched Moments by token ID or drop ID.
+
+## 0.8.0
+
+- `createBoolFilter` in `@poap-xyz/utils` has been removed. Use `createEqFilter('...', true | false)` instead.

--- a/docs/pages/packages/utils/Queries.mdx
+++ b/docs/pages/packages/utils/Queries.mdx
@@ -54,14 +54,12 @@ For example:
 ```typescript
 import {
   FilterVariables,
-  createBoolFilter,
   createLikeFilter,
   createBetweenFilter,
 } from '@poap-xyz/utils';
 
 const variables: FilterVariables = {
   where: {
-    ...createBoolFilter('private', true),
     ...createLikeFilter('name', 'My Awesome POAP'),
     ...createBetweenFilter('created_date', '2023-12-23', '2024-02-28'),
   },
@@ -73,7 +71,6 @@ The possible filters to create are:
 - `createLikeFilter`: searches for the value to be included case-insensitive in the field.
 - `createEqFilter`: match exact field value.
 - `createNeqFilter`: match not equal field value.
-- `createBoolFilter`: when the value is true or false.
 - `createAddressFilter`: given the address match it case-insensitive.
 - `createNotNullAddressFilter`: excludes the zero and/or dead addresses.
 - `createInFilter`: if the field is contained in any of the given values.

--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.5",
-    "@poap-xyz/utils": "0.7.5"
+    "@poap-xyz/providers": "0.8.0",
+    "@poap-xyz/utils": "0.8.0"
   }
 }

--- a/packages/drops/src/DropsClient.ts
+++ b/packages/drops/src/DropsClient.ts
@@ -1,8 +1,8 @@
 import { CompassProvider, DropApiProvider } from '@poap-xyz/providers';
 import {
   createBetweenFilter,
-  createBoolFilter,
   createInFilter,
+  createEqFilter,
   createLikeFilter,
   createOrderBy,
   isNumeric,
@@ -73,7 +73,7 @@ export class DropsClient {
       offset,
       orderBy: createOrderBy<DropsSortFields>(sortField, sortDir),
       where: {
-        ...createBoolFilter('private', isPrivate),
+        ...createEqFilter('private', isPrivate),
         ...createLikeFilter('name', name),
         ...createBetweenFilter('created_date', from, to),
         ...createInFilter('id', ids),

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,8 +31,8 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.5",
-    "@poap-xyz/utils": "0.7.5",
+    "@poap-xyz/providers": "0.8.0",
+    "@poap-xyz/utils": "0.8.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.7.5",
-    "@poap-xyz/utils": "0.7.5"
+    "@poap-xyz/providers": "0.8.0",
+    "@poap-xyz/utils": "0.8.0"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/utils": "0.7.5",
+    "@poap-xyz/utils": "0.8.0",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/utils/src/queries/filter.ts
+++ b/packages/utils/src/queries/filter.ts
@@ -67,6 +67,9 @@ export function createNotNullAddressFilter(
   if (filteredAddresses.length === 0) {
     return {};
   }
+  if (filteredAddresses.length === 1) {
+    return createField<NeqFilter<string>>(key, { _neq: filteredAddresses[0] });
+  }
   return createField<NinFilter<string>>(key, { _nin: filteredAddresses });
 }
 

--- a/packages/utils/src/queries/filter.ts
+++ b/packages/utils/src/queries/filter.ts
@@ -14,12 +14,13 @@ import {
   Value,
 } from '../types/filter';
 import { ZERO_ADDRESS, DEAD_ADDRESS } from '../constants';
+import { isFilterValueDefined } from '../validation/isFilterValueDefined';
 
 export function createLikeFilter(
   key: string,
   value?: string,
 ): FieldFilter<LikeFilter<string>> {
-  return value
+  return isFilterValueDefined(value)
     ? createField<LikeFilter<string>>(key, { _ilike: `%${value}%` })
     : {};
 }
@@ -28,24 +29,17 @@ export function createEqFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<EqFilter<V>> {
-  return value ? createField<EqFilter<V>>(key, { _eq: value }) : {};
+  return isFilterValueDefined(value)
+    ? createField<EqFilter<V>>(key, { _eq: value })
+    : {};
 }
 
 export function createNeqFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<NeqFilter<V>> {
-  return value ? createField<NeqFilter<V>>(key, { _neq: value }) : {};
-}
-
-export function createBoolFilter(
-  key: string,
-  value?: boolean,
-): FieldFilter<EqFilter<'true' | 'false'>> {
-  return typeof value === 'boolean'
-    ? createField<EqFilter<'true' | 'false'>>(key, {
-        _eq: value ? 'true' : 'false',
-      })
+  return isFilterValueDefined(value)
+    ? createField<NeqFilter<V>>(key, { _neq: value })
     : {};
 }
 
@@ -53,40 +47,34 @@ export function createAddressFilter(
   key: string,
   value?: string,
 ): FieldFilter<EqFilter<string>> {
-  return value
+  return isFilterValueDefined(value)
     ? createField<EqFilter<string>>(key, { _eq: value.toLowerCase() })
     : {};
 }
 
-// eslint-disable-next-line complexity
 export function createNotNullAddressFilter(
   key: string,
-  filterZeroAddress = true,
-  filterDeadAddress = true,
+  filterZeroAddress?: boolean,
+  filterDeadAddress?: boolean,
 ): FieldFilter<NeqFilter<string>> | FieldFilter<NinFilter<string>> {
-  if (filterZeroAddress && filterDeadAddress) {
-    return createField<NinFilter<string>>(key, {
-      _nin: [ZERO_ADDRESS, DEAD_ADDRESS],
-    });
+  const filteredAddresses: string[] = [];
+  if (filterZeroAddress !== false) {
+    filteredAddresses.push(ZERO_ADDRESS);
   }
-  if (filterZeroAddress) {
-    return createField<NeqFilter<string>>(key, {
-      _neq: ZERO_ADDRESS,
-    });
+  if (filterDeadAddress !== false) {
+    filteredAddresses.push(DEAD_ADDRESS);
   }
-  if (filterDeadAddress) {
-    return createField<NeqFilter<string>>(key, {
-      _neq: DEAD_ADDRESS,
-    });
+  if (filteredAddresses.length === 0) {
+    return {};
   }
-  return {};
+  return createField<NinFilter<string>>(key, { _nin: filteredAddresses });
 }
 
 export function createInFilter<V = Value>(
   key: string,
   values?: Array<V>,
 ): FieldFilter<InFilter<V>> {
-  return values && values.length > 0
+  return isFilterValueDefined(values)
     ? createField<InFilter<V>>(key, { _in: values })
     : {};
 }
@@ -95,7 +83,7 @@ export function createNinFilter<V = Value>(
   key: string,
   values?: Array<V>,
 ): FieldFilter<NinFilter<V>> {
-  return values && values.length > 0
+  return isFilterValueDefined(values)
     ? createField<NinFilter<V>>(key, { _nin: values })
     : {};
 }
@@ -104,28 +92,36 @@ export function createLtFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<LtFilter<V>> {
-  return value ? createField<LtFilter<V>>(key, { _lt: value }) : {};
+  return isFilterValueDefined(value)
+    ? createField<LtFilter<V>>(key, { _lt: value })
+    : {};
 }
 
 export function createLteFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<LteFilter<V>> {
-  return value ? createField<LteFilter<V>>(key, { _lte: value }) : {};
+  return isFilterValueDefined(value)
+    ? createField<LteFilter<V>>(key, { _lte: value })
+    : {};
 }
 
 export function createGtFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<GtFilter<V>> {
-  return value ? createField<GtFilter<V>>(key, { _gt: value }) : {};
+  return isFilterValueDefined(value)
+    ? createField<GtFilter<V>>(key, { _gt: value })
+    : {};
 }
 
 export function createGteFilter<V = Value>(
   key: string,
   value?: V,
 ): FieldFilter<GteFilter<V>> {
-  return value ? createField<GteFilter<V>>(key, { _gte: value }) : {};
+  return isFilterValueDefined(value)
+    ? createField<GteFilter<V>>(key, { _gte: value })
+    : {};
 }
 
 export function createBetweenFilter<V = Value>(
@@ -134,13 +130,15 @@ export function createBetweenFilter<V = Value>(
   to?: V,
 ): FieldFilter<Partial<GteFilter<V>> & Partial<LteFilter<V>>> {
   const betweenFilter: Partial<GteFilter<V>> & Partial<LteFilter<V>> = {};
-  if (from) {
+  const isFromDefined = isFilterValueDefined(from);
+  const isToDefined = isFilterValueDefined(to);
+  if (isFromDefined) {
     betweenFilter._gte = from;
   }
-  if (to) {
+  if (isToDefined) {
     betweenFilter._lte = to;
   }
-  return from || to
+  return isFromDefined || isToDefined
     ? createField<Partial<GteFilter<V>> & Partial<LteFilter<V>>>(
         key,
         betweenFilter,

--- a/packages/utils/src/validation/isFilterValueDefined.ts
+++ b/packages/utils/src/validation/isFilterValueDefined.ts
@@ -1,0 +1,30 @@
+/**
+ * Checks if a value given to a query filter is defined.
+ *
+ * @param {V} value The value to check.
+ * @returns {boolean} True if the value is defined, false otherwise.
+ */
+export function isFilterValueDefined<V>(value?: V): value is NonNullable<V> {
+  if (value == null) {
+    return false;
+  }
+
+  switch (typeof value) {
+    case 'boolean':
+      return true;
+    case 'number':
+      return isNumberDefined(value);
+    case 'object':
+      return isObjectDefined(value);
+    default:
+      return !!value;
+  }
+}
+
+function isNumberDefined(value: number): value is NonNullable<number> {
+  return !isNaN(value) && value !== 0;
+}
+
+function isObjectDefined<V>(value: V & object): boolean {
+  return Object.keys(value).length > 0;
+}

--- a/packages/utils/test/validation/isFilterValueDefined.spec.ts
+++ b/packages/utils/test/validation/isFilterValueDefined.spec.ts
@@ -1,0 +1,35 @@
+import { isFilterValueDefined } from '../../src/validation/isFilterValueDefined';
+
+describe('isFilterValueDefined', () => {
+  it('should accept a string if it is not empty', () => {
+    expect(isFilterValueDefined('')).toBe(false);
+    expect(isFilterValueDefined('a')).toBe(true);
+  });
+
+  it('should accept all boolean values', () => {
+    expect(isFilterValueDefined(true)).toBe(true);
+    expect(isFilterValueDefined(false)).toBe(true);
+  });
+
+  it('should accept all numbers except 0 and NaN', () => {
+    expect(isFilterValueDefined(0)).toBe(false);
+    expect(isFilterValueDefined(NaN)).toBe(false);
+    expect(isFilterValueDefined(1)).toBe(true);
+    expect(isFilterValueDefined(-1)).toBe(true);
+  });
+
+  it('should accept all objects with at least one key', () => {
+    expect(isFilterValueDefined({})).toBe(false);
+    expect(isFilterValueDefined({ a: 1 })).toBe(true);
+  });
+
+  it('should accept arrays with at least one element', () => {
+    expect(isFilterValueDefined([])).toBe(false);
+    expect(isFilterValueDefined([1])).toBe(true);
+  });
+
+  it('should reject null and undefined values', () => {
+    expect(isFilterValueDefined(null)).toBe(false);
+    expect(isFilterValueDefined(undefined)).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,8 +931,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.7.5
-    "@poap-xyz/utils": 0.7.5
+    "@poap-xyz/providers": 0.8.0
+    "@poap-xyz/utils": 0.8.0
   languageName: unknown
   linkType: soft
 
@@ -948,8 +948,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.7.5
-    "@poap-xyz/utils": 0.7.5
+    "@poap-xyz/providers": 0.8.0
+    "@poap-xyz/utils": 0.8.0
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -959,16 +959,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.7.5
-    "@poap-xyz/utils": 0.7.5
+    "@poap-xyz/providers": 0.8.0
+    "@poap-xyz/utils": 0.8.0
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.7.5, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.8.0, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.7.5
+    "@poap-xyz/utils": 0.8.0
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -976,7 +976,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.7.5, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.8.0, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

* `createEqFilter` will now accept 0 or false, for example. Will refuse actually undefined values.
* Also remove `createBoolFilter` as it's the same as `createEqFilter`. (I'm open to different opinions on this, we could deprecate or keep it).
* (minor) Added printing of the name of the package being built in the build script.

Found this when trying to use `createGtFilter('...', 0)` and my filter wouldn't be applied.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
