### PR TITLE
build: Minify JS builds and keep JSDoc in declaration files

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.0",
-    "@poap-xyz/utils": "0.8.0"
+    "@poap-xyz/providers": "0.8.1",
+    "@poap-xyz/utils": "0.8.1"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,8 +31,8 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.0",
-    "@poap-xyz/utils": "0.8.0",
+    "@poap-xyz/providers": "0.8.1",
+    "@poap-xyz/utils": "0.8.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.0",
-    "@poap-xyz/utils": "0.8.0"
+    "@poap-xyz/providers": "0.8.1",
+    "@poap-xyz/utils": "0.8.1"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/utils": "0.8.0",
+    "@poap-xyz/utils": "0.8.1",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -2,6 +2,7 @@ import typescript from 'rollup-plugin-typescript2';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import terser from '@rollup/plugin-terser';
 import path from 'path';
 import nodePolyfills from 'rollup-plugin-node-polyfills';
 
@@ -16,7 +17,6 @@ const configs = [
       file: pkg.browser,
       format: 'umd',
       exports: 'named',
-      sourcemap: true,
     },
     cache: false,
     plugins: [
@@ -26,6 +26,7 @@ const configs = [
       }),
       commonjs(),
       json(),
+      terser({ sourceMap: true }),
     ],
   },
   {
@@ -34,13 +35,11 @@ const configs = [
       {
         file: pkg.main,
         format: 'cjs',
-        sourcemap: true,
         exports: 'named',
       },
       {
         file: pkg.module,
         format: 'esm',
-        sourcemap: true,
         exports: 'named',
       },
     ],
@@ -54,6 +53,7 @@ const configs = [
       commonjs(),
       nodePolyfills(),
       json(),
+      terser({ sourceMap: true }),
     ],
   },
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,8 +931,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.8.0
-    "@poap-xyz/utils": 0.8.0
+    "@poap-xyz/providers": 0.8.1
+    "@poap-xyz/utils": 0.8.1
   languageName: unknown
   linkType: soft
 
@@ -948,8 +948,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.8.0
-    "@poap-xyz/utils": 0.8.0
+    "@poap-xyz/providers": 0.8.1
+    "@poap-xyz/utils": 0.8.1
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -959,16 +959,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.8.0
-    "@poap-xyz/utils": 0.8.0
+    "@poap-xyz/providers": 0.8.1
+    "@poap-xyz/utils": 0.8.1
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@0.8.0, @poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.8.1, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.8.0
+    "@poap-xyz/utils": 0.8.1
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -976,7 +976,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@0.8.0, @poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.8.1, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

* Use terser to minify the build and generate sourcemaps
* Use terser to remove all comments from all compiled JS code
* Keep JSDoc in typescript declaration files

Allows reading JSDoc in the editor when hovering:

<img width="850" alt="image" src="https://github.com/user-attachments/assets/173f2539-f3e4-4278-b8be-a07d57cb1c8a" />



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation accordingly.
