### PR TITLE
docs: Fix typos and improve grammar throughout documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,5 +15,5 @@ Closes # (issue)
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+- [ ] All new and existing tests pass.
 - [ ] I have updated the documentation accordingly.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@
 >
 > This product is in development and is not intended to be used in a production environment.
 >
-> If you want to collaborate and leave us feedback, you can do it
-> so [here](https://github.com/poap-xyz/poap.js/discussions/19)
+> If you want to collaborate and leave us feedback, you can do so [here](https://github.com/poap-xyz/poap.js/discussions/19)
 
 # POAP.js
 
 ![Build Status](https://github.com/poap-xyz/poap.js/actions/workflows/npm_publish.yml/badge.svg)
 
-The POAP.js is a collection of SDKs and utilities for interacting with the POAP ecosystem. The
+POAP.js is a collection of SDKs and utilities for interacting with the POAP ecosystem. The
 library provides a set of classes and methods to simplify working with it.
 
 ## Table of Contents

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -2,18 +2,18 @@
 >
 > The POAP SDK is still in active initial development phase. Anything MAY change at any time.
 >
-> This is a Developer Preview aimed primarily at existing integrators so to gather early feedback.
+> This is a Developer Preview aimed primarily at existing integrators to gather early feedback.
 > Documentation is in progress.
 >
 > This product is in development and is not intended to be used in a production environment.
 >
-> If you want to collaborate and leave us feedback you can do it so [here](https://github.com/poap-xyz/poap.js/discussions/19).
+> If you want to collaborate and leave us feedback, you can do so [here](https://github.com/poap-xyz/poap.js/discussions/19).
 
 # Introduction
  
 This page will help you get started with POAP. You'll be up and running in a jiffy!
 
-Welcome! We're excited you're here! 
+Welcome! We're excited you're here!
 
 You're on your way to building an awesome integration! Here's some of the things you'll want to check out.
 
@@ -31,7 +31,7 @@ POAP is a protocol for the preservation of memories as digital records, minted a
 
 The POAP platform offers numerous functionalities exposed through an API. Everyone is free to use POAP's API to obtain information regarding POAPs minted, drops created, etc. 
 
-Additionally, you can use the API to create your applications on top of POAP by automating POAP distributions. For this, you will need API authorization tokens. Please refer to [Authentication](https://documentation.poap.tech/docs/authentication) for more information on requesting authorization tokens.  
+Additionally, you can use the API to create your applications on top of POAP by automating POAP distributions; for this, you will need API authorization tokens. Please refer to [Authentication](https://documentation.poap.tech/docs/authentication) for more information on requesting authorization tokens.
 
 [Learn more about POAP](https://poap.zendesk.com/hc/en-us/articles/9494654007437-What-Is-POAP-).
 

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -15,7 +15,7 @@ This page will help you get started with POAP. You'll be up and running in a jif
 
 Welcome! We're excited you're here!
 
-You're on your way to building an awesome integration! Here's some of the things you'll want to check out.
+You're on your way to building an awesome integration! Here are some of the things you'll want to check out.
 
 ## Overview
 
@@ -35,6 +35,6 @@ Additionally, you can use the API to create your applications on top of POAP by 
 
 [Learn more about POAP](https://poap.zendesk.com/hc/en-us/articles/9494654007437-What-Is-POAP-).
 
-Before using our API, we suggest a quick read through our [Help Center](https://poap.zendesk.com/hc/en-us) in order to better understand the POAP ecosystem.
+Before using our API, we suggest a quick read through our [Help Center](https://poap.zendesk.com/hc/en-us) to better understand the POAP ecosystem.
 
 Before getting started, there is some POAP terminology that may be worth familiarizing yourself with, as these will be referenced frequently throughout the documentation. Go ahead and explore [the POAP glossary](https://poap.zendesk.com/hc/en-us/articles/10477884588429-The-POAP-Glossary) to get up to speed on the vocabulary.

--- a/docs/pages/packages/drops/CreateDrop.mdx
+++ b/docs/pages/packages/drops/CreateDrop.mdx
@@ -1,7 +1,7 @@
 # Create Drop
 
 Using `DropsClient` to [setup a Drop](https://poap.zendesk.com/hc/en-us/articles/9702718846989-How-do-I-set-up-a-POAP-Drop)
-is straightforward, there is no need of being authenticated with an email and
+is straightforward, there is no need to be authenticated with an email and
 the only requirements are having the API key.
 
 ```typescript

--- a/docs/pages/packages/moments/FetchMoments.mdx
+++ b/docs/pages/packages/moments/FetchMoments.mdx
@@ -18,7 +18,7 @@ const paginatedMoments: PaginatedResult<Moment> = await client.fetch({
 
 ### By Drop
 
-The list can be filtered by one or more Drops by giving `drop_ids` list with the
+The list can be filtered by one or more Drops by giving `dropIds` list with the
 Drop IDs. Also, the list can be sorted by `id` or `created`.
 
 ```typescript
@@ -30,7 +30,7 @@ const dropId = 14;
 const paginatedMoments: PaginatedResult<Moment> = await client.fetch({
   offset: 0,
   limit: 10,
-  drop_ids: [dropId],
+  dropIds: [dropId],
   idOrder: Order.DESC,
 });
 ```

--- a/docs/pages/packages/poaps.mdx
+++ b/docs/pages/packages/poaps.mdx
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/poaps` is a JavaScript library providing an interface for interacting with POAPs , making it easy to fetch information about POAP tokens like their on-chain data, their related drop information and metadata.
+`@poap-xyz/poaps` is a JavaScript library providing an interface for interacting with POAPs, making it easy to fetch information about POAP tokens like their on-chain data, their related drop information and metadata.
 
 ## Features
 

--- a/docs/pages/packages/poaps/FetchPOAPs.mdx
+++ b/docs/pages/packages/poaps/FetchPOAPs.mdx
@@ -4,7 +4,7 @@ Once POAPs have been minted they can be fetched with `PoapsClient`.
 
 ## Fetch single POAP
 
-To retrieve one POAP it can be done with it's ID.
+To retrieve one POAP it can be done with its ID.
 
 ```typescript
 import { POAP } from '@poap-xyz/poaps';

--- a/docs/pages/packages/poaps/Mint.mdx
+++ b/docs/pages/packages/poaps/Mint.mdx
@@ -46,4 +46,4 @@ const poap: POAP = await client.mintSync({
 });
 ```
 
-Don't forget to handle [custom errors](Errors).
+Don't forget to handle [custom errors](/packages/poaps/Errors).

--- a/docs/pages/packages/providers.mdx
+++ b/docs/pages/packages/providers.mdx
@@ -2,12 +2,12 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/providers` is a package to use POAP providers that let you interact with POAPs APIs. Also you can make your own provider by extending the interfaces.
+`@poap-xyz/providers` is a package to use POAP providers that let you interact with POAP APIs. Also you can make your own provider by extending the interfaces.
 
 ## Features
 
 - Interfaces to interact with POAP APIs
-- POAP custom Providers so you can use without implementing one.
+- POAP custom Providers so you can use them without implementing one.
 
 ## Installation
 

--- a/docs/pages/packages/providers/Compass.mdx
+++ b/docs/pages/packages/providers/Compass.mdx
@@ -13,8 +13,8 @@ const compass = new PoapCompass({
 ## Requests
 
 Query requests can be made by giving the query in string and optionally the variables to pass. All
-success requests are returned as an object with a `data` property which the structure differs
-depending on the query done. When the request fail, errors are thrown instead.
+successful requests are returned as an object with a `data` property where the structure differs
+depending on the query done. When the request fails, errors are thrown instead.
 
 ### Querying
 
@@ -72,7 +72,7 @@ try {
 ### Errors
 
 There are two types of errors, HTTP errors and requests errors. The former are thrown when there is
-an issue with the HTTP requests itself and the later when the query has some malformed or
+an issue with the HTTP requests itself and the latter when the query has some malformed or
 unavailable structure.
 
 #### HTTP errors

--- a/packages/moments/README.md
+++ b/packages/moments/README.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- Create a Moment attached to a Drop or an specific POAP
+- Create a Moment attached to a Drop or a specific POAP
 - Fetch multiple Moments
 - Fetch a single Moment
 

--- a/packages/moments/src/client/MomentsClient.ts
+++ b/packages/moments/src/client/MomentsClient.ts
@@ -24,7 +24,7 @@ import { CreateAndUploadMomentInput } from './dtos/create/CreateAndUploadInput';
 export class MomentsClient {
   constructor(
     private poapMomentsApi: PoapMomentsApi,
-    private CompassProvider: CompassProvider,
+    private compassProvider: CompassProvider,
   ) {}
 
   /** Uploads media files first, then creates the Moment. */
@@ -168,7 +168,7 @@ export class MomentsClient {
       },
     };
 
-    const response = await this.CompassProvider.request<
+    const response = await this.compassProvider.request<
       MomentsQueryResponse,
       MomentsQueryVariables
     >(PAGINATED_MOMENTS_QUERY, variables);

--- a/packages/poaps/README.md
+++ b/packages/poaps/README.md
@@ -9,14 +9,12 @@ information and metadata.
 ## Features
 
 - Fetch one or multiple POAP tokens at once.
-- Search over minted POAPs by their collector or the drop they belong to.
-- Mint POAPs synchronously or asynchronously mint processes.
+- Search for minted POAPs by their collector or the drop they belong to.
+- Mint POAPs using synchronous or asynchronous processes.
 - Reserve a POAP to an email address.
 - Obtain mint status, POAP indexed status, and more.
 
 ## Installation
-
-This package doesn't require any additional dependencies for installation.
 
 ### NPM
 

--- a/packages/poaps/src/PoapsClient.ts
+++ b/packages/poaps/src/PoapsClient.ts
@@ -121,12 +121,12 @@ export class PoapsClient {
   }
 
   /**
-   * Gets the Transaction associated with the mint.
-   * The Transaction could change in case of a bump.
+   * Gets the transaction associated with the mint.
+   * The transaction could change in case of a bump.
    * It returns null if the mint has no transaction associated.
    *
    * @param {string} qrHash - The qrHash of the mint.
-   * @returns {Promise<Transaction> | null} The Transaction associated with the mint. Null if no transaction is found.
+   * @returns {Promise<Transaction> | null} Returns the transaction associated with the mint. Null if no transaction is found.
    */
   public async getMintTransaction(qrHash: string): Promise<Transaction | null> {
     return await this.tokensApiProvider.getMintTransaction(qrHash);

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
-`@poap-xyz/providers` is a package to use POAP providers that let you interact with POAPs APIs. Also
+`@poap-xyz/providers` is a package to use POAP providers that let you interact with POAP APIs. Also,
 you can make your own provider by extending the interfaces.
 
 ## Features

--- a/packages/providers/src/core/PoapMomentsApi/PoapMomentsApi.ts
+++ b/packages/providers/src/core/PoapMomentsApi/PoapMomentsApi.ts
@@ -18,9 +18,9 @@ export class PoapMomentsApi implements MomentsApiProvider {
 
   /**
    * @constructor
-   * * @param {Object} params - Object containing constructor parameters.
-   *  * @param {string} [params.baseUrl='https://moments.poap.xyz'] - The base URL for the POAP Moments API.
-   *  * @param {AuthenticationProvider} [params.authenticationProvider] - Optional authentication provider only used for write operations.ication provider only used for write operations
+   * @param {Object} params - Object containing constructor parameters.
+   * @param {string} [params.baseUrl='https://moments.poap.xyz'] - The base URL for the POAP Moments API.
+   * @param {AuthenticationProvider} [params.authenticationProvider] - Optional authentication provider only used for write operations.
    */
   constructor(params: {
     baseUrl?: string;


### PR DESCRIPTION
- Fix inconsistent terminology and phrasing in documentation files
- Correct grammatical errors in README files and documentation
- Standardize use of 'its' vs 'it's' across the codebase
- Make casing consistent for 'transaction' references
- Improve flow in documentation by using proper punctuation
- Fix inconsistent parameter naming in documentation examples

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>