### PR TITLE
feat: Relax query util value validations

### DIFF
--- a/packages/drops/package.json
+++ b/packages/drops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/drops",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Drops module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.1",
-    "@poap-xyz/utils": "0.8.1"
+    "@poap-xyz/providers": "0.8.3",
+    "@poap-xyz/utils": "0.8.3"
   }
 }

--- a/packages/moments/package.json
+++ b/packages/moments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/moments",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Moments module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,8 +31,8 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.1",
-    "@poap-xyz/utils": "0.8.1",
+    "@poap-xyz/providers": "0.8.3",
+    "@poap-xyz/utils": "0.8.3",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/poaps/package.json
+++ b/packages/poaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poaps",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Poaps module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/providers": "0.8.1",
-    "@poap-xyz/utils": "0.8.1"
+    "@poap-xyz/providers": "0.8.3",
+    "@poap-xyz/utils": "0.8.3"
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/providers",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Providers module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
@@ -31,7 +31,7 @@
   },
   "packageManager": "yarn@3.5.0",
   "dependencies": {
-    "@poap-xyz/utils": "0.8.1",
+    "@poap-xyz/utils": "0.8.3",
     "axios": "^1.6.8",
     "lodash.chunk": "^4.2.0"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/utils",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Utils module for the poap.js library",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",

--- a/packages/utils/src/validation/isFilterValueDefined.ts
+++ b/packages/utils/src/validation/isFilterValueDefined.ts
@@ -11,20 +11,11 @@ export function isFilterValueDefined<V>(value?: V): value is NonNullable<V> {
 
   switch (typeof value) {
     case 'boolean':
+    case 'object':
       return true;
     case 'number':
-      return isNumberDefined(value);
-    case 'object':
-      return isObjectDefined(value);
+      return !isNaN(value);
     default:
       return !!value;
   }
-}
-
-function isNumberDefined(value: number): value is NonNullable<number> {
-  return !isNaN(value) && value !== 0;
-}
-
-function isObjectDefined<V>(value: V & object): boolean {
-  return Object.keys(value).length > 0;
 }

--- a/packages/utils/test/validation/isFilterValueDefined.spec.ts
+++ b/packages/utils/test/validation/isFilterValueDefined.spec.ts
@@ -11,20 +11,20 @@ describe('isFilterValueDefined', () => {
     expect(isFilterValueDefined(false)).toBe(true);
   });
 
-  it('should accept all numbers except 0 and NaN', () => {
-    expect(isFilterValueDefined(0)).toBe(false);
+  it('should accept all numbers except NaN', () => {
     expect(isFilterValueDefined(NaN)).toBe(false);
+    expect(isFilterValueDefined(0)).toBe(true);
     expect(isFilterValueDefined(1)).toBe(true);
     expect(isFilterValueDefined(-1)).toBe(true);
   });
 
-  it('should accept all objects with at least one key', () => {
-    expect(isFilterValueDefined({})).toBe(false);
+  it('should accept all objects', () => {
+    expect(isFilterValueDefined({})).toBe(true);
     expect(isFilterValueDefined({ a: 1 })).toBe(true);
   });
 
-  it('should accept arrays with at least one element', () => {
-    expect(isFilterValueDefined([])).toBe(false);
+  it('should accept all arrays', () => {
+    expect(isFilterValueDefined([])).toBe(true);
     expect(isFilterValueDefined([1])).toBe(true);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,8 +931,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/drops@workspace:packages/drops"
   dependencies:
-    "@poap-xyz/providers": 0.8.1
-    "@poap-xyz/utils": 0.8.1
+    "@poap-xyz/providers": 0.8.3
+    "@poap-xyz/utils": 0.8.3
   languageName: unknown
   linkType: soft
 
@@ -948,8 +948,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/moments@workspace:packages/moments"
   dependencies:
-    "@poap-xyz/providers": 0.8.1
-    "@poap-xyz/utils": 0.8.1
+    "@poap-xyz/providers": 0.8.3
+    "@poap-xyz/utils": 0.8.3
     "@types/uuid": ^9.0.2
     uuid: ^9.0.0
   languageName: unknown
@@ -959,27 +959,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@poap-xyz/poaps@workspace:packages/poaps"
   dependencies:
-    "@poap-xyz/providers": 0.8.1
-    "@poap-xyz/utils": 0.8.1
+    "@poap-xyz/providers": 0.8.3
+    "@poap-xyz/utils": 0.8.3
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/providers@npm:0.8.1":
-  version: 0.8.1
-  resolution: "@poap-xyz/providers@npm:0.8.1"
-  dependencies:
-    "@poap-xyz/utils": 0.8.1
-    axios: ^1.6.8
-    lodash.chunk: ^4.2.0
-  checksum: 1b23076cba0e73800ebfbca312426c3e7a6d3382a7715701dad6fdc1fb850d7caa2778d3299581605feae6be255b7fd4301fd260442c6afcd26f1a22aea1f223
-  languageName: node
-  linkType: hard
-
-"@poap-xyz/providers@workspace:packages/providers":
+"@poap-xyz/providers@0.8.3, @poap-xyz/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/providers@workspace:packages/providers"
   dependencies:
-    "@poap-xyz/utils": 0.8.1
+    "@poap-xyz/utils": 0.8.3
     axios: ^1.6.8
     axios-mock-adapter: ^1.21.4
     jest-fetch-mock: ^3.0.3
@@ -987,14 +976,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@poap-xyz/utils@npm:0.8.1":
-  version: 0.8.1
-  resolution: "@poap-xyz/utils@npm:0.8.1"
-  checksum: ffe1a1b5ff46c78d8dafd3dfafb43029ed46dd9676136ba91843595bc8826c05ced57659d755cd2565d25d054e1987a4ffdd4809a64a0c2d913abec809236594
-  languageName: node
-  linkType: hard
-
-"@poap-xyz/utils@workspace:packages/utils":
+"@poap-xyz/utils@0.8.3, @poap-xyz/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@poap-xyz/utils@workspace:packages/utils"
   languageName: unknown


### PR DESCRIPTION
## Description

It's sometimes valid to give an empty array, or the number 0 to a query. We should allow it.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
