### PR TITLE
build: Keep entrypoint file in package export

### DIFF
--- a/packages/poap-sdk/package.json
+++ b/packages/poap-sdk/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "SDK for everything POAP",
-  "main": "dist/cjs/",
-  "module": "dist/esm/",
-  "typings": "dist/cjs/",
+  "main": "dist/cjs/index/index.cjs",
+  "module": "dist/esm/index/index.mjs",
+  "typings": "dist/cjs/index.d.ts",
   "exports": {
     "./*": {
       "require": "./dist/cjs/*/index.cjs",
@@ -12,8 +12,8 @@
       "types": "./dist/cjs/*/index.d.ts"
     },
     ".": {
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index/index.cjs",
+      "import": "./dist/esm/index/index.mjs",
       "types": "./dist/cjs/index.d.ts"
     }
   },

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -25,13 +25,13 @@ const configs = [
     input,
     output: [
       {
-        dir: pkg.main,
+        dir: pkg.main.replace(/index.*/, ''),
         format: 'cjs',
         exports: 'named',
         entryFileNames: '[name]/index.cjs',
       },
       {
-        dir: pkg.module,
+        dir: pkg.module.replace(/index.*/, ''),
         format: 'esm',
         exports: 'named',
         entryFileNames: '[name]/index.mjs',


### PR DESCRIPTION
It was removed to use directories in the build, but it's needed for some libraries to find the entrypoint of the lib.
