### PR TITLE
build: Avoid subpackage imports to keep support for CJS

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,6 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   clearMocks: true,
   moduleNameMapper: {
-    '^@poap-xyz/poap-sdk/(.*)$': '<rootDir>/packages/poap-sdk/src/$1',
+    '^@poap-xyz/poap-sdk$': '<rootDir>/packages/poap-sdk/src',
   },
 };

--- a/packages/poap-sdk/package.json
+++ b/packages/poap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "SDK for everything POAP",
   "main": "dist/cjs/index/index.cjs",
   "module": "dist/esm/index/index.mjs",

--- a/packages/poap-sdk/src/drops/DropsClient.ts
+++ b/packages/poap-sdk/src/drops/DropsClient.ts
@@ -1,5 +1,6 @@
-import { CompassProvider, DropApiProvider } from '@poap-xyz/poap-sdk/providers';
 import {
+  CompassProvider,
+  DropApiProvider,
   createBetweenFilter,
   createInFilter,
   createEqFilter,
@@ -10,7 +11,7 @@ import {
   Order,
   PaginatedResult,
   toPOAPDate,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 import { Drop } from './domain/Drop';
 import {
   PAGINATED_DROPS_QUERY,

--- a/packages/poap-sdk/src/drops/domain/Drop.ts
+++ b/packages/poap-sdk/src/drops/domain/Drop.ts
@@ -1,4 +1,4 @@
-import { DropResponse as ProviderDropResponse } from '@poap-xyz/poap-sdk/providers';
+import { DropResponse as ProviderDropResponse } from '@poap-xyz/poap-sdk';
 import { DropResponse } from '../types/DropResponse';
 import { DropImage } from './DropImage';
 

--- a/packages/poap-sdk/src/drops/queries/PaginatedDrop.ts
+++ b/packages/poap-sdk/src/drops/queries/PaginatedDrop.ts
@@ -2,7 +2,7 @@ import {
   FilterVariables,
   OrderByVariables,
   PaginatedVariables,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 import { DropResponse } from '../types/DropResponse';
 
 export const PAGINATED_DROPS_QUERY = `

--- a/packages/poap-sdk/src/drops/queries/SearchDrops.ts
+++ b/packages/poap-sdk/src/drops/queries/SearchDrops.ts
@@ -1,4 +1,4 @@
-import { Order, PaginatedVariables } from '@poap-xyz/poap-sdk/utils';
+import { Order, PaginatedVariables } from '@poap-xyz/poap-sdk';
 import { DropResponse } from '../types/DropResponse';
 
 export const SEARCH_DROPS_QUERY = `

--- a/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
+++ b/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
@@ -1,4 +1,4 @@
-import { Order, PaginationInput } from '@poap-xyz/poap-sdk/utils';
+import { Order, PaginationInput } from '@poap-xyz/poap-sdk';
 import { DropsSortFields } from './DropsSortFields';
 
 export interface FetchDropsInput extends PaginationInput {

--- a/packages/poap-sdk/src/drops/types/SearchDropsInput.ts
+++ b/packages/poap-sdk/src/drops/types/SearchDropsInput.ts
@@ -1,4 +1,4 @@
-import { PaginationInput } from '@poap-xyz/poap-sdk/utils';
+import { PaginationInput } from '@poap-xyz/poap-sdk';
 
 export interface SearchDropsInput extends PaginationInput {
   search: string;

--- a/packages/poap-sdk/src/moments/client/MomentsClient.spec.ts
+++ b/packages/poap-sdk/src/moments/client/MomentsClient.spec.ts
@@ -1,5 +1,5 @@
 import { mock, MockProxy } from 'jest-mock-extended';
-import { PoapCompass, PoapMomentsApi } from '@poap-xyz/poap-sdk/providers';
+import { PoapCompass, PoapMomentsApi } from '@poap-xyz/poap-sdk';
 import { MomentsClient } from './MomentsClient';
 import { CreateMomentInput } from './dtos/create/CreateInput';
 import { CreateSteps } from './dtos/create/CreateSteps';

--- a/packages/poap-sdk/src/moments/client/MomentsClient.ts
+++ b/packages/poap-sdk/src/moments/client/MomentsClient.ts
@@ -1,5 +1,6 @@
-import { CompassProvider, PoapMomentsApi } from '@poap-xyz/poap-sdk/providers';
 import {
+  CompassProvider,
+  PoapMomentsApi,
   createBetweenFilter,
   createEqFilter,
   createInFilter,
@@ -7,7 +8,7 @@ import {
   createOrderBy,
   nextCursor,
   PaginatedResult,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 import { Moment } from '../domain/Moment';
 import {
   MomentsQueryResponse,

--- a/packages/poap-sdk/src/moments/client/MomentsClientFactory/MomentsClientFactory.ts
+++ b/packages/poap-sdk/src/moments/client/MomentsClientFactory/MomentsClientFactory.ts
@@ -3,7 +3,7 @@ import {
   AuthenticationProviderHttp,
   PoapCompass,
   PoapMomentsApi,
-} from '@poap-xyz/poap-sdk/providers';
+} from '@poap-xyz/poap-sdk';
 import { MomentsClient } from '../MomentsClient';
 import { GetMomentsDefaultClientOptions } from './options/GetMomentsDefaultClientOptions';
 

--- a/packages/poap-sdk/src/moments/client/MomentsClientFactory/options/GetMomentsDefaultClientOptions.ts
+++ b/packages/poap-sdk/src/moments/client/MomentsClientFactory/options/GetMomentsDefaultClientOptions.ts
@@ -1,4 +1,4 @@
-import { AuthenticationProvider } from '@poap-xyz/poap-sdk/providers';
+import { AuthenticationProvider } from '@poap-xyz/poap-sdk';
 
 interface MomentsBaseOptions {
   /**

--- a/packages/poap-sdk/src/moments/client/dtos/fetch/FetchMomentsInput.ts
+++ b/packages/poap-sdk/src/moments/client/dtos/fetch/FetchMomentsInput.ts
@@ -1,4 +1,4 @@
-import { Order, PaginationInput } from '@poap-xyz/poap-sdk/utils';
+import { Order, PaginationInput } from '@poap-xyz/poap-sdk';
 
 /**
  * Interface representing the input needed to fetch moments.

--- a/packages/poap-sdk/src/moments/domain/Moment.ts
+++ b/packages/poap-sdk/src/moments/domain/Moment.ts
@@ -1,4 +1,4 @@
-import { CreateMomentResponse } from '@poap-xyz/poap-sdk/providers';
+import { CreateMomentResponse } from '@poap-xyz/poap-sdk';
 import { MomentResponse } from '../queries/PaginatedMoments';
 
 /**

--- a/packages/poap-sdk/src/moments/queries/PaginatedMoments.ts
+++ b/packages/poap-sdk/src/moments/queries/PaginatedMoments.ts
@@ -2,7 +2,7 @@ import {
   FilterVariables,
   OrderByVariables,
   PaginatedVariables,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 
 export const PAGINATED_MOMENTS_QUERY = /* GraphQL */ `
   query PaginatedMoments(

--- a/packages/poap-sdk/src/poaps/PoapsClient.ts
+++ b/packages/poap-sdk/src/poaps/PoapsClient.ts
@@ -2,8 +2,6 @@ import {
   CompassProvider,
   TokensApiProvider,
   Transaction,
-} from '@poap-xyz/poap-sdk/providers';
-import {
   createAddressFilter,
   createBetweenFilter,
   createEqFilter,
@@ -12,7 +10,7 @@ import {
   createOrderBy,
   nextCursor,
   PaginatedResult,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 import { POAP } from './domain/POAP';
 import { POAPReservation } from './domain/POAPReservation';
 import {

--- a/packages/poap-sdk/src/poaps/queries/PaginatedPoaps.ts
+++ b/packages/poap-sdk/src/poaps/queries/PaginatedPoaps.ts
@@ -2,7 +2,7 @@ import {
   FilterVariables,
   OrderByVariables,
   PaginatedVariables,
-} from '@poap-xyz/poap-sdk/utils';
+} from '@poap-xyz/poap-sdk';
 
 export const PAGINATED_POAPS_QUERY = `
   query PaginatedPoaps(

--- a/packages/poap-sdk/src/poaps/types/FetchPoapsInput.ts
+++ b/packages/poap-sdk/src/poaps/types/FetchPoapsInput.ts
@@ -1,4 +1,4 @@
-import { Order, Chain, PaginationInput } from '@poap-xyz/poap-sdk/utils';
+import { Order, Chain, PaginationInput } from '@poap-xyz/poap-sdk';
 import { PoapsSortFields } from './PoapsSortFields';
 
 /**

--- a/packages/poap-sdk/src/poaps/utils/MintChecker.ts
+++ b/packages/poap-sdk/src/poaps/utils/MintChecker.ts
@@ -2,7 +2,7 @@ import {
   TokensApiProvider,
   Transaction,
   TransactionStatus,
-} from '@poap-xyz/poap-sdk/providers';
+} from '@poap-xyz/poap-sdk';
 import { FinishedWithError } from '../errors/FinishedWithError';
 import { RetryableTask } from './RetryableTask';
 

--- a/packages/poap-sdk/src/poaps/utils/PoapIndexed.ts
+++ b/packages/poap-sdk/src/poaps/utils/PoapIndexed.ts
@@ -1,4 +1,4 @@
-import { TokensApiProvider } from '@poap-xyz/poap-sdk/providers';
+import { TokensApiProvider } from '@poap-xyz/poap-sdk';
 import { RetryableTask } from './RetryableTask';
 import { PoapMintStatus } from '../types/PoapMintStatus';
 

--- a/packages/poap-sdk/src/poaps/utils/RetryableTask.ts
+++ b/packages/poap-sdk/src/poaps/utils/RetryableTask.ts
@@ -1,4 +1,4 @@
-import { TokensApiProvider } from '@poap-xyz/poap-sdk/providers';
+import { TokensApiProvider } from '@poap-xyz/poap-sdk';
 
 const MAX_RETRIES = 20;
 const INITIAL_DELAY = 1000;

--- a/packages/poap-sdk/test/poaps/PoapsClient.spec.ts
+++ b/packages/poap-sdk/test/poaps/PoapsClient.spec.ts
@@ -1,8 +1,5 @@
 import { MockProxy, anyString, mock } from 'jest-mock-extended';
-import {
-  CompassProvider,
-  TokensApiProvider,
-} from '@poap-xyz/poap-sdk/providers';
+import { CompassProvider, TokensApiProvider } from '@poap-xyz/poap-sdk';
 import { PoapsClient } from '../../src/poaps/PoapsClient';
 
 describe('PoapsClient', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,11 +24,7 @@
     "downlevelIteration": true,
     "noImplicitAny": false,
     "paths": {
-      "@poap-xyz/poap-sdk/drops": ["./poap-sdk/src/drops"],
-      "@poap-xyz/poap-sdk/moments": ["./poap-sdk/src/moments"],
-      "@poap-xyz/poap-sdk/poaps": ["./poap-sdk/src/poaps"],
-      "@poap-xyz/poap-sdk/providers": ["./poap-sdk/src/providers"],
-      "@poap-xyz/poap-sdk/utils": ["./poap-sdk/src/utils"]
+      "@poap-xyz/poap-sdk": ["./poap-sdk/src"]
     }
   },
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
There are other solutions to this issue, but this keeps it simple for now. Keeps support for subpackage import with ESM, and doesn't break any imports using CJS.