### PR TITLE
[Profiles] feat: Keep first profile when multiple are returned

### DIFF
--- a/packages/poap-sdk/package.json
+++ b/packages/poap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "SDK for everything POAP",
   "main": "dist/cjs/index/index.cjs",
   "module": "dist/esm/index/index.mjs",

--- a/packages/poap-sdk/src/profiles/ProfilesClient.ts
+++ b/packages/poap-sdk/src/profiles/ProfilesClient.ts
@@ -47,14 +47,15 @@ export class ProfilesClient {
       queries,
       options,
     );
-    if (!profiles.length) {
-      return new Map();
-    }
 
     const map = new Map<string, Profile>();
-    for (const profileResponse of profiles) {
+    for (const response of profiles) {
+      if (map.has(response.address.toLowerCase())) {
+        continue;
+      }
+
       const profile = Profile.fromResponse(
-        profileResponse,
+        response,
         this.profileApiProvider.apiUrl,
       );
       map.set(profile.address.toLowerCase(), profile);


### PR DESCRIPTION
## Description

* When multiple profiles are returned for the same address, use the first one in the list to build the map instead of the last one.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
