### PR TITLE
Fix typo

### DIFF
--- a/packages/poap-sdk/src/providers/core/PoapCollectionsApi/PoapCollectionsApi.ts
+++ b/packages/poap-sdk/src/providers/core/PoapCollectionsApi/PoapCollectionsApi.ts
@@ -51,7 +51,7 @@ export class PoapCollectionsApi implements CollectionsApiProvider {
   }
 
   /**
-   * Applies a update to an existing collection in the POAP Collections API.
+   * Applies an update to an existing collection in the POAP Collections API.
    *
    * @public
    * @async

--- a/packages/poap-sdk/src/providers/core/PoapDropApi/PoapDropApi.ts
+++ b/packages/poap-sdk/src/providers/core/PoapDropApi/PoapDropApi.ts
@@ -29,7 +29,7 @@ export class PoapDropApi implements DropApiProvider {
   }
 
   /**
-   * Creates a new drop on the POAP Drop API.
+   * Creates a new drop via the POAP Drop API.
    *
    * @async
    * @function
@@ -56,7 +56,7 @@ export class PoapDropApi implements DropApiProvider {
   }
 
   /**
-   * Updates an existing drop on the POAP Drop API.
+   * Updates an existing drop via the POAP Drop API.
    *
    * @async
    * @function


### PR DESCRIPTION
Replaced "on the API" → "via the API" in JSDoc (more accurate wording).

Fixed "a update" → "an update" (grammar).