### PR TITLE
feat: Add serializable profile type and methods

### DIFF
--- a/packages/poap-sdk/package.json
+++ b/packages/poap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "SDK for everything POAP",
   "main": "dist/cjs/index/index.cjs",
   "module": "dist/esm/index/index.mjs",

--- a/packages/poap-sdk/src/profiles/domain/Profile.ts
+++ b/packages/poap-sdk/src/profiles/domain/Profile.ts
@@ -10,6 +10,10 @@ export class Profile {
     public fresh: number,
   ) {}
 
+  public toSerializable(): SerializableProfile {
+    return { ...this };
+  }
+
   public static fromResponse(
     response: ProfileResponse,
     apiUrl: string,
@@ -22,4 +26,22 @@ export class Profile {
       response.fresh,
     );
   }
+
+  public static fromSerializable(serializable: SerializableProfile): Profile {
+    return new Profile(
+      serializable.address,
+      serializable.ens,
+      serializable.avatar,
+      serializable.header,
+      serializable.fresh,
+    );
+  }
 }
+
+export type SerializableProfile = {
+  address: string;
+  ens: string;
+  avatar: string | null;
+  header: string | null;
+  fresh: number;
+};

--- a/packages/poap-sdk/src/profiles/index.ts
+++ b/packages/poap-sdk/src/profiles/index.ts
@@ -1,2 +1,2 @@
 export { ProfilesClient } from './ProfilesClient';
-export { Profile } from './domain/Profile';
+export { Profile, SerializableProfile } from './domain/Profile';


### PR DESCRIPTION
## Description

In most frontend frameworks, classes can't be passed on from server to client components. This helper, used in other domains of this SDK, allows a profile to be sent to a client component from the server.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
