### PR TITLE
[Drops] refactor: Clean up fetch drops input

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -40,3 +40,11 @@
   - Changed `drop_ids` to `dropIds` in `FetchMomentsInput` interface.
   - Updated `MomentsClient.fetch` method to use the camelCase `dropIds` parameter.
   - GraphQL field names still use snake_case (e.g., `drop_id`) for backend compatibility.
+
+## 0.11.0
+
+- `DropsClient.fetch` property changes:
+	- `name` is removed as a filter. Use `DropsClient.search` instead.
+	- `isPrivate` is removed as a filter.
+	- `from` and `to` date range now filters based on the drop event start and
+	end dates, instead of the drop creation date.

--- a/packages/poap-sdk/package.json
+++ b/packages/poap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poap-xyz/poap-sdk",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "description": "SDK for everything POAP",
   "main": "dist/cjs/index/index.cjs",
   "module": "dist/esm/index/index.mjs",

--- a/packages/poap-sdk/src/drops/DropsClient.ts
+++ b/packages/poap-sdk/src/drops/DropsClient.ts
@@ -68,7 +68,7 @@ export class DropsClient {
       orderBy: createOrderBy<DropsSortFields>(sortField, sortDir),
       where: {
         ...(isDateRangeDefined && {
-          _or: [
+          _and: [
             createBetweenFilter('start_date', from, to),
             createBetweenFilter('end_date', from, to),
           ],

--- a/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
+++ b/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
@@ -1,12 +1,13 @@
 import { Order, PaginationInput } from '@poap-xyz/poap-sdk';
 import { DropsSortFields } from './DropsSortFields';
 
-export interface FetchDropsInput extends PaginationInput {
-  name?: string;
+export type FetchDropsInput = PaginationInput & {
   sortField?: DropsSortFields;
   sortDir?: Order;
+  /** Drop event start date to start from the given date. */
   from?: string;
+  /** Drop event start date to end on or before the given date. */
   to?: string;
+  /** List of drop IDs to filter the drops. */
   ids?: number[];
-  isPrivate?: boolean;
-}
+};

--- a/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
+++ b/packages/poap-sdk/src/drops/types/FetchDropsInput.ts
@@ -4,9 +4,9 @@ import { DropsSortFields } from './DropsSortFields';
 export type FetchDropsInput = PaginationInput & {
   sortField?: DropsSortFields;
   sortDir?: Order;
-  /** Drop event start date to start from the given date. */
+  /** Drop event date range to happen from or after the given date. */
   from?: string;
-  /** Drop event start date to end on or before the given date. */
+  /** Drop event date range to happen up to or before the given date. */
   to?: string;
   /** List of drop IDs to filter the drops. */
   ids?: number[];


### PR DESCRIPTION
Goal of the PR is to clean up the properties a little to prepare for adding more filters, like fetch drops in Collection, drops by artist, moments, etc.

Changes:

* Remove fetch by name. Replaced by search.
* Remove fetch by "is private". Not a relevant property anymore.
* Update the fetch by date range to include start and end dates.

(up for discussion)