### PR TITLE
[Profiles] feat: fetchBulk returns errors on failed resolutions

### DIFF
--- a/packages/poap-sdk/src/profiles/ProfilesClient.ts
+++ b/packages/poap-sdk/src/profiles/ProfilesClient.ts
@@ -1,5 +1,9 @@
 import { ProfilesApiProvider } from '../providers';
 import { Profile } from './domain/Profile';
+import { FetchBulkProfilesResponse } from './dtos/FetchBulkProfilesResponse';
+import { ProfileError } from './domain/ProfileError';
+import { ProfileResponse } from '../providers/ports/ProfilesApiProvider/types/ProfileResponse';
+import { ProfilesBulkError } from '../providers/ports/ProfilesApiProvider/types/ProfilesBulkError';
 
 export class ProfilesClient {
   /**
@@ -28,29 +32,36 @@ export class ProfilesClient {
    * ```typescript
    * const address1 = '0x1234...';
    * const address2 = '0x5678...';
-   * const profiles = await profilesClient.fetchBulk([address1, address2]);
+   * const { profiles, errors } = await profilesClient.fetchBulk([address1, address2]);
    * console.log(profiles.get(address1)?.ens); // 'test.eth'
    * console.log(profiles.get('test.eth')?.address); // '0x1234...'
    * console.log(profiles.get(address2)?.ens); // undefined
+   * console.log(errors.get(address2)?.message); // 'Profile not found'
    * ```
    *
    * @param queries The ETH addresses or ENS.
    * @param options Options to pass to the fetch call.
-   * @returns A map of input addresses (ETH address or ENS) to profiles. All
-   * map keys are lowercased.
+   * @returns A map of input addresses (ETH address or ENS) to profiles, and a map of failed queries to errors.
    */
   async fetchBulk(
     queries: string[],
     options?: RequestInit,
-  ): Promise<Map<string, Profile>> {
-    const profiles = await this.profileApiProvider.getBulkProfiles(
+  ): Promise<FetchBulkProfilesResponse> {
+    const { profiles, errors } = await this.profileApiProvider.getBulkProfiles(
       queries,
       options,
     );
 
-    const map = new Map<string, Profile>();
+    return {
+      profiles: this.createProfilesMap(profiles),
+      errors: this.createErrorsMap(errors || []),
+    };
+  }
+
+  private createProfilesMap(profiles: ProfileResponse[]): Map<string, Profile> {
+    const profilesMap = new Map<string, Profile>();
     for (const response of profiles) {
-      if (map.has(response.address.toLowerCase())) {
+      if (profilesMap.has(response.address)) {
         continue;
       }
 
@@ -58,9 +69,21 @@ export class ProfilesClient {
         response,
         this.profileApiProvider.apiUrl,
       );
-      map.set(profile.address.toLowerCase(), profile);
-      map.set(profile.ens.toLowerCase(), profile);
+      profilesMap.set(profile.address, profile);
+      if (profile.ens) {
+        profilesMap.set(profile.ens, profile);
+      }
     }
-    return map;
+    return profilesMap;
+  }
+
+  private createErrorsMap(
+    errors: ProfilesBulkError[],
+  ): Map<string, ProfileError> {
+    const errorsMap = new Map<string, ProfileError>();
+    for (const error of errors) {
+      errorsMap.set(error.id, { message: error.message });
+    }
+    return errorsMap;
   }
 }

--- a/packages/poap-sdk/src/profiles/domain/ProfileError.ts
+++ b/packages/poap-sdk/src/profiles/domain/ProfileError.ts
@@ -1,0 +1,3 @@
+export interface ProfileError {
+  message: string;
+}

--- a/packages/poap-sdk/src/profiles/dtos/FetchBulkProfilesResponse.ts
+++ b/packages/poap-sdk/src/profiles/dtos/FetchBulkProfilesResponse.ts
@@ -1,0 +1,7 @@
+import { Profile } from '../domain/Profile';
+import { ProfileError } from '../domain/ProfileError';
+
+export interface FetchBulkProfilesResponse {
+  profiles: Map<string, Profile>;
+  errors: Map<string, ProfileError>;
+}

--- a/packages/poap-sdk/src/providers/core/PoapProfilesApi/PoapProfilesApi.ts
+++ b/packages/poap-sdk/src/providers/core/PoapProfilesApi/PoapProfilesApi.ts
@@ -39,25 +39,31 @@ export class PoapProfilesApi implements ProfilesApiProvider {
    * the list is too big.
    * @param queries ETH addresses or ENS
    * @param options Options to pass to the fetch call.
-   * @returns The list of responses from the API.
+   * @returns The list of responses from the API and errors (if any).
    */
   async getBulkProfiles(
     queries: string[],
     options?: RequestInit,
-  ): Promise<ProfileResponse[]> {
+  ): Promise<BulkProfilesResponse> {
     if (queries.length === 0) {
-      return [];
+      return { profiles: [] };
     }
 
     if (queries.length === 1) {
       const profile = await this.getProfile(queries[0], options);
-      return profile ? [profile] : [];
+      return { profiles: profile ? [profile] : [] };
     }
 
     const batchResult = await this.batchBulkProfilesRequest(queries, options);
     return batchResult.reduce(
-      (profiles, response) => profiles.concat(response.profiles),
-      [] as ProfileResponse[],
+      (acc, response) => {
+        acc.profiles.push(...response.profiles);
+        if (response.errors) {
+          acc.errors = (acc.errors || []).concat(response.errors);
+        }
+        return acc;
+      },
+      { profiles: [], errors: [] } as BulkProfilesResponse,
     );
   }
 

--- a/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/ProfilesApiProvider.ts
+++ b/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/ProfilesApiProvider.ts
@@ -1,3 +1,4 @@
+import { BulkProfilesResponse } from './types/BulkProfilesResponse';
 import { ProfileResponse } from './types/ProfileResponse';
 
 export interface ProfilesApiProvider {
@@ -17,10 +18,10 @@ export interface ProfilesApiProvider {
    * the list is too big.
    * @param queries ETH addresses or ENS
    * @param options Options to pass to the fetch call.
-   * @returns The list of responses from the API.
+   * @returns The list of responses from the API and errors (if any).
    */
   getBulkProfiles(
     queries: string[],
     options?: RequestInit,
-  ): Promise<ProfileResponse[]>;
+  ): Promise<BulkProfilesResponse>;
 }

--- a/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/types/BulkProfilesResponse.ts
+++ b/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/types/BulkProfilesResponse.ts
@@ -1,5 +1,7 @@
+import { ProfilesBulkError } from './ProfilesBulkError';
 import { ProfileResponse } from './ProfileResponse';
 
 export interface BulkProfilesResponse {
   profiles: ProfileResponse[];
+  errors?: ProfilesBulkError[];
 }

--- a/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/types/ProfilesBulkError.ts
+++ b/packages/poap-sdk/src/providers/ports/ProfilesApiProvider/types/ProfilesBulkError.ts
@@ -1,0 +1,4 @@
+export interface ProfilesBulkError {
+  id: string;
+  message: string;
+}


### PR DESCRIPTION
## Description

The API bulk call returns an array of errors, this PR handles the returned errors array and returns it in the `fetchBulk` method. Addresses are also no longer lower cased when returned.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
