### PR TITLE
[Providers] Auth Token Rate Limit Reached Error

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## Next Version
+
+{<h3>Features</h3>}
+
+* **[Providers]** `AuthenticationProvider.getAuthToken` now throws a `RateLimitReachedError`.
+
+## 0.21.0
+
+ESM support.
+
 ## 0.20.0
 
 {<h3>Features</h3>}

--- a/src/providers/ports/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/providers/ports/AuthenticationProvider/AuthenticationProvider.ts
@@ -10,6 +10,7 @@ export interface AuthenticationProvider {
    *
    * @param audience The audience of the API
    * @throws {UnauthorizedClientError}
+   * @throws {RateLimitReachedError} when too many tokens are requested
    */
   getAuthToken(audience: string): Promise<AuthToken>;
 }

--- a/src/providers/ports/AuthenticationProvider/errors/RateLimitReachedError.ts
+++ b/src/providers/ports/AuthenticationProvider/errors/RateLimitReachedError.ts
@@ -1,0 +1,18 @@
+import { UnauthorizedClientError } from './UnauthorizedClientError.js';
+
+export class RateLimitReachedError extends UnauthorizedClientError {
+  public readonly resetTimestamp: string | undefined;
+  public readonly resetDate: Date | undefined;
+
+  constructor(clientId: string, audience: string, responseHeaders: Headers) {
+    super(clientId, audience);
+
+    this.resetTimestamp =
+      responseHeaders['X-RateLimit-Reset'] ??
+      responseHeaders['x-ratelimit-reset'];
+
+    if (this.resetTimestamp) {
+      this.resetDate = new Date(parseInt(this.resetTimestamp) * 1000);
+    }
+  }
+}

--- a/src/providers/ports/AuthenticationProvider/errors/index.ts
+++ b/src/providers/ports/AuthenticationProvider/errors/index.ts
@@ -1,2 +1,3 @@
 export * from './MissingAuthenticationProviderError.js';
 export * from './UnauthorizedClientError.js';
+export * from './RateLimitReachedError.js';


### PR DESCRIPTION
## Description

Add supports when requesting `https://{auth0domain}/oauth/token` many times that returns:

```{"error":"Rate limit reached","error_description":"Access Denied"}```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poap-xyz/poap.js/blob/main/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have updated the documentation accordingly.
